### PR TITLE
GH Actions

### DIFF
--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -6,9 +6,13 @@ on:
       - master
     tags:
       - v*
+    paths-ignore:
+      - "**.md"
     pull_request:
       branches:
         - master
+      paths-ignore:
+        - "**.md"
 jobs:
   deploy:
     runs-on: ubuntu-16.04

--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+    pull_request:
+      branches:
+        - master
+jobs:
+  deploy:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: MeilCli/setup-crystal-action@v4.0.1
+        with:
+          crystal_version: 0.35.1
+          shards_version: 0.12.0
+      - name: Install dependencies
+        run: shards install
+      - name: Run tests
+        run: crystal spec
+      - name: Run crystal tool format
+        run: crystal tool format --check
+      - name: Build examples
+        run: find examples -name "*.cr" | xargs -L 1 crystal build --no-codegen

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -6,6 +6,8 @@ on:
       - master
     tags:
       - v*
+    paths-ignore:
+      - "CHANGELOG.md"
 jobs:
   deploy:
     runs-on: ubuntu-16.04

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,32 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+jobs:
+  deploy:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: MeilCli/setup-crystal-action@v4.0.1
+        with:
+          crystal_version: 0.35.1
+          shards_version: 0.12.0
+      - name: Install dependencies
+        run: shards install
+      - name: Run crystal doc
+        run: crystal doc
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3.7.0-8
+        with:
+          personal_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs
+          destination_dir: ${{ steps.extract_branch.outputs.branch }}
+

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -817,7 +817,7 @@ module Discord
     #
     # [API docs for this event](https://discordapp.com/developers/docs/topics/gateway#invite-create)
     event invite_create, Gateway::InviteCreatePayload
-    
+
     # Called when an invite is deleted.
     #
     # [API docs for this event](https://discordapp.com/developers/docs/topics/gateway#invite-delete)


### PR DESCRIPTION
This adds 2 github actions:
- Building and deploying docs to `gh-pages`
- Tool format + specs + building examples to ensure the lib is still buildable.

Deploying docs only runs on tags and master, while the build step runs on master + any pull requests made.