### PR TITLE
feat: 0.35.1 support

### DIFF
--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -2,15 +2,17 @@ require "yaml"
 require "./spec_helper"
 
 struct StructWithTime
-  JSON.mapping(
-    data: {type: Time, converter: Discord::TimestampConverter}
-  )
+  include JSON::Serializable
+
+  @[JSON::Field(converter: Discord::TimestampConverter)]
+  property data : Time
 end
 
 struct StructWithMaybeTime
-  JSON.mapping(
-    data: {type: Time?, converter: Discord::MaybeTimestampConverter, emit_null: true}
-  )
+  include JSON::Serializable
+
+  @[JSON::Field(converter: Discord::MaybeTimestampConverter, emit_null: true)]
+  property data : Time?
 end
 
 describe Discord do

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -817,7 +817,7 @@ module Discord
     #
     # [API docs for this event](https://discordapp.com/developers/docs/topics/gateway#invite-create)
     event invite_create, Gateway::InviteCreatePayload
-    
+
     # Called when an invite is deleted.
     #
     # [API docs for this event](https://discordapp.com/developers/docs/topics/gateway#invite-delete)

--- a/src/discordcr/dca.cr
+++ b/src/discordcr/dca.cr
@@ -90,61 +90,61 @@ module Discord
   # Mappings for DCA1 metadata
   module DCA1Mappings
     struct Metadata
-      JSON.mapping(
-        dca: DCA,
-        opus: Opus,
-        info: Info?,
-        origin: Origin?,
-        extra: JSON::Any
-      )
+      include JSON::Serializable
+
+      property dca : DCA
+      property opus : Opus
+      property info : Info?
+      property origin : Origin?
+      property extra : JSON::Any
     end
 
     struct DCA
-      JSON.mapping(
-        version: Int32,
-        tool: Tool
-      )
+      include JSON::Serializable
+
+      property version : Int32
+      property tool : Tool
     end
 
     struct Tool
-      JSON.mapping(
-        name: String,
-        version: String,
-        url: String?,
-        author: String?
-      )
+      include JSON::Serializable
+
+      property name : String
+      property version : String
+      property url : String?
+      property author : String?
     end
 
     struct Opus
-      JSON.mapping(
-        mode: String,
-        sample_rate: Int32,
-        frame_size: Int32,
-        abr: Int32?,
-        vbr: Bool,
-        channels: Int32
-      )
+      include JSON::Serializable
+
+      property mode : String
+      property sample_rate : Int32
+      property frame_size : Int32
+      property abr : Int32?
+      property vbr : Bool
+      property channels : Int32
     end
 
     struct Info
-      JSON.mapping(
-        title: String?,
-        artist: String?,
-        album: String?,
-        genre: String?,
-        comments: String?,
-        cover: String?
-      )
+      include JSON::Serializable
+
+      property title : String?
+      property artist : String?
+      property album : String?
+      property genre : String?
+      property comments : String?
+      property cover : String?
     end
 
     struct Origin
-      JSON.mapping(
-        source: String?,
-        abr: Int32?,
-        channels: Int32?,
-        encoding: String?,
-        url: String?
-      )
+      include JSON::Serializable
+
+      property source : String?
+      property abr : Int32?
+      property channels : Int32?
+      property encoding : String?
+      property url : String?
     end
   end
 end

--- a/src/discordcr/errors.cr
+++ b/src/discordcr/errors.cr
@@ -33,10 +33,10 @@ module Discord
 
   # An API error response.
   struct APIError
-    JSON.mapping(
-      code: Int32,
-      message: String
-    )
+    include JSON::Serializable
+
+    property code : Int32
+    property message : String
   end
 
   # This exception is raised in `REST#request` when a request fails with an

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -77,14 +77,6 @@ module Discord
   end
 
   struct Channel
-    # :nodoc:
-    def initialize(private_channel : PrivateChannel)
-      @id = private_channel.id
-      @type = private_channel.type
-      @recipients = private_channel.recipients
-      @last_message_id = private_channel.last_message_id
-    end
-
     include JSON::Serializable
 
     property id : Snowflake
@@ -104,6 +96,14 @@ module Discord
     property position : Int32?
     property parent_id : Snowflake?
     property rate_limit_per_user : Int32?
+
+    # :nodoc:
+    def initialize(private_channel : PrivateChannel)
+      @id = private_channel.id
+      @type = private_channel.type
+      @recipients = private_channel.recipients
+      @last_message_id = private_channel.last_message_id
+    end
 
     # Produces a string to mention this channel in a message
     def mention
@@ -145,14 +145,6 @@ module Discord
   end
 
   struct Embed
-    def initialize(@title : String? = nil, @type : String = "rich",
-                   @description : String? = nil, @url : String? = nil,
-                   @timestamp : Time? = nil, @colour : UInt32? = nil,
-                   @footer : EmbedFooter? = nil, @image : EmbedImage? = nil,
-                   @thumbnail : EmbedThumbnail? = nil, @author : EmbedAuthor? = nil,
-                   @fields : Array(EmbedField)? = nil)
-    end
-
     include JSON::Serializable
 
     property title : String?
@@ -171,6 +163,14 @@ module Discord
     property author : EmbedAuthor?
     property fields : Array(EmbedField)?
 
+    def initialize(@title : String? = nil, @type : String = "rich",
+                   @description : String? = nil, @url : String? = nil,
+                   @timestamp : Time? = nil, @colour : UInt32? = nil,
+                   @footer : EmbedFooter? = nil, @image : EmbedImage? = nil,
+                   @thumbnail : EmbedThumbnail? = nil, @author : EmbedAuthor? = nil,
+                   @fields : Array(EmbedField)? = nil)
+    end
+
     {% unless flag?(:correct_english) %}
       def color
         colour
@@ -179,15 +179,15 @@ module Discord
   end
 
   struct EmbedThumbnail
-    def initialize(@url : String)
-    end
-
     include JSON::Serializable
 
     property url : String
     property proxy_url : String?
     property height : UInt32?
     property width : UInt32?
+
+    def initialize(@url : String)
+    end
   end
 
   struct EmbedVideo
@@ -199,15 +199,15 @@ module Discord
   end
 
   struct EmbedImage
-    def initialize(@url : String)
-    end
-
     include JSON::Serializable
 
     property url : String
     property proxy_url : String?
     property height : UInt32?
     property width : UInt32?
+
+    def initialize(@url : String)
+    end
   end
 
   struct EmbedProvider
@@ -218,37 +218,48 @@ module Discord
   end
 
   struct EmbedAuthor
-    def initialize(@name : String? = nil, @url : String? = nil, @icon_url : String? = nil)
-    end
-
     include JSON::Serializable
 
     property name : String?
     property url : String?
     property icon_url : String?
     property proxy_icon_url : String?
+
+    def initialize(
+      @name : String? = nil,
+      @url : String? = nil,
+      @icon_url : String? = nil
+    )
+    end
   end
 
   struct EmbedFooter
-    def initialize(@text : String? = nil, @icon_url : String? = nil)
-    end
-
     include JSON::Serializable
 
     property text : String?
     property icon_url : String?
     property proxy_icon_url : String?
+
+    def initialize(
+      @text : String? = nil,
+      @icon_url : String? = nil
+    )
+    end
   end
 
   struct EmbedField
-    def initialize(@name : String, @value : String, @inline : Bool = false)
-    end
-
     include JSON::Serializable
 
     property name : String
     property value : String
     property inline : Bool
+
+    def initialize(
+      @name : String,
+      @value : String,
+      @inline : Bool = false
+    )
+    end
   end
 
   struct Attachment

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -21,26 +21,27 @@ module Discord
   end
 
   struct Message
-    JSON.mapping(
-      type: MessageType,
-      content: String,
-      id: Snowflake,
-      channel_id: Snowflake,
-      guild_id: Snowflake?,
-      author: User,
-      member: PartialGuildMember?,
-      timestamp: {type: Time, converter: TimestampConverter},
-      tts: Bool,
-      mention_everyone: Bool,
-      mentions: Array(User),
-      mention_roles: Array(Snowflake),
-      attachments: Array(Attachment),
-      embeds: Array(Embed),
-      pinned: Bool?,
-      reactions: Array(Reaction)?,
-      nonce: String | Int64?,
-      activity: Activity?
-    )
+    include JSON::Serializable
+
+    property type : MessageType
+    property content : String
+    property id : Snowflake
+    property channel_id : Snowflake
+    property guild_id : Snowflake?
+    property author : User
+    property member : PartialGuildMember?
+    @[JSON::Field(converter: Discord::TimestampConverter)]
+    property timestamp : Time
+    property tts : Bool
+    property mention_everyone : Bool
+    property mentions : Array(User)
+    property mention_roles : Array(Snowflake)
+    property attachments : Array(Attachment)
+    property embeds : Array(Embed)
+    property pinned : Bool?
+    property reactions : Array(Reaction)?
+    property nonce : String | Int64?
+    property activity : Activity?
   end
 
   enum ActivityType : UInt8
@@ -55,10 +56,10 @@ module Discord
   end
 
   struct Activity
-    JSON.mapping(
-      type: ActivityType,
-      party_id: String?
-    )
+    include JSON::Serializable
+
+    property type : ActivityType
+    property party_id : String?
   end
 
   enum ChannelType : UInt8
@@ -84,25 +85,25 @@ module Discord
       @last_message_id = private_channel.last_message_id
     end
 
-    JSON.mapping(
-      id: Snowflake,
-      type: ChannelType,
-      guild_id: Snowflake?,
-      name: String?,
-      permission_overwrites: Array(Overwrite)?,
-      topic: String?,
-      last_message_id: Snowflake?,
-      bitrate: UInt32?,
-      user_limit: UInt32?,
-      recipients: Array(User)?,
-      nsfw: Bool?,
-      icon: String?,
-      owner_id: Snowflake?,
-      application_id: Snowflake?,
-      position: Int32?,
-      parent_id: Snowflake?,
-      rate_limit_per_user: Int32?
-    )
+    include JSON::Serializable
+
+    property id : Snowflake
+    property type : ChannelType
+    property guild_id : Snowflake?
+    property name : String?
+    property permission_overwrites : Array(Overwrite)?
+    property topic : String?
+    property last_message_id : Snowflake?
+    property bitrate : UInt32?
+    property user_limit : UInt32?
+    property recipients : Array(User)?
+    property nsfw : Bool?
+    property icon : String?
+    property owner_id : Snowflake?
+    property application_id : Snowflake?
+    property position : Int32?
+    property parent_id : Snowflake?
+    property rate_limit_per_user : Int32?
 
     # Produces a string to mention this channel in a message
     def mention
@@ -111,36 +112,36 @@ module Discord
   end
 
   struct PrivateChannel
-    JSON.mapping(
-      id: Snowflake,
-      type: ChannelType,
-      recipients: Array(User),
-      last_message_id: Snowflake?
-    )
+    include JSON::Serializable
+
+    property id : Snowflake
+    property type : ChannelType
+    property recipients : Array(User)
+    property last_message_id : Snowflake?
   end
 
   struct Overwrite
-    JSON.mapping(
-      id: Snowflake,
-      type: String,
-      allow: Permissions,
-      deny: Permissions
-    )
+    include JSON::Serializable
+
+    property id : Snowflake
+    property type : String
+    property allow : Permissions
+    property deny : Permissions
   end
 
   struct Reaction
-    JSON.mapping(
-      emoji: ReactionEmoji,
-      count: UInt32,
-      me: Bool
-    )
+    include JSON::Serializable
+
+    property emoji : ReactionEmoji
+    property count : UInt32
+    property me : Bool
   end
 
   struct ReactionEmoji
-    JSON.mapping(
-      id: Snowflake?,
-      name: String
-    )
+    include JSON::Serializable
+
+    property id : Snowflake?
+    property name : String
   end
 
   struct Embed
@@ -152,21 +153,23 @@ module Discord
                    @fields : Array(EmbedField)? = nil)
     end
 
-    JSON.mapping(
-      title: String?,
-      type: String,
-      description: String?,
-      url: String?,
-      timestamp: {type: Time?, converter: MaybeTimestampConverter},
-      colour: {type: UInt32?, key: "color"},
-      footer: EmbedFooter?,
-      image: EmbedImage?,
-      thumbnail: EmbedThumbnail?,
-      video: EmbedVideo?,
-      provider: EmbedProvider?,
-      author: EmbedAuthor?,
-      fields: Array(EmbedField)?
-    )
+    include JSON::Serializable
+
+    property title : String?
+    property type : String
+    property description : String?
+    property url : String?
+    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+    property timestamp : Time?
+    @[JSON::Field(key: "color")]
+    property colour : UInt32?
+    property footer : EmbedFooter?
+    property image : EmbedImage?
+    property thumbnail : EmbedThumbnail?
+    property video : EmbedVideo?
+    property provider : EmbedProvider?
+    property author : EmbedAuthor?
+    property fields : Array(EmbedField)?
 
     {% unless flag?(:correct_english) %}
       def color
@@ -179,84 +182,84 @@ module Discord
     def initialize(@url : String)
     end
 
-    JSON.mapping(
-      url: String,
-      proxy_url: String?,
-      height: UInt32?,
-      width: UInt32?
-    )
+    include JSON::Serializable
+
+    property url : String
+    property proxy_url : String?
+    property height : UInt32?
+    property width : UInt32?
   end
 
   struct EmbedVideo
-    JSON.mapping(
-      url: String,
-      height: UInt32,
-      width: UInt32
-    )
+    include JSON::Serializable
+
+    property url : String
+    property height : UInt32
+    property width : UInt32
   end
 
   struct EmbedImage
     def initialize(@url : String)
     end
 
-    JSON.mapping(
-      url: String,
-      proxy_url: String?,
-      height: UInt32?,
-      width: UInt32?
-    )
+    include JSON::Serializable
+
+    property url : String
+    property proxy_url : String?
+    property height : UInt32?
+    property width : UInt32?
   end
 
   struct EmbedProvider
-    JSON.mapping(
-      name: String,
-      url: String?
-    )
+    include JSON::Serializable
+
+    property name : String
+    property url : String?
   end
 
   struct EmbedAuthor
     def initialize(@name : String? = nil, @url : String? = nil, @icon_url : String? = nil)
     end
 
-    JSON.mapping(
-      name: String?,
-      url: String?,
-      icon_url: String?,
-      proxy_icon_url: String?
-    )
+    include JSON::Serializable
+
+    property name : String?
+    property url : String?
+    property icon_url : String?
+    property proxy_icon_url : String?
   end
 
   struct EmbedFooter
     def initialize(@text : String? = nil, @icon_url : String? = nil)
     end
 
-    JSON.mapping(
-      text: String?,
-      icon_url: String?,
-      proxy_icon_url: String?
-    )
+    include JSON::Serializable
+
+    property text : String?
+    property icon_url : String?
+    property proxy_icon_url : String?
   end
 
   struct EmbedField
     def initialize(@name : String, @value : String, @inline : Bool = false)
     end
 
-    JSON.mapping(
-      name: String,
-      value: String,
-      inline: Bool
-    )
+    include JSON::Serializable
+
+    property name : String
+    property value : String
+    property inline : Bool
   end
 
   struct Attachment
-    JSON.mapping(
-      id: Snowflake,
-      filename: String,
-      size: UInt32,
-      url: String,
-      proxy_url: String,
-      height: UInt32?,
-      width: UInt32?
-    )
+    include JSON::Serializable
+
+    property id : Snowflake
+    property filename : String
+    property size : UInt32
+    property url : String
+    property proxy_url : String
+    property height : UInt32?
+    property width : UInt32?
   end
 end

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -207,6 +207,8 @@ module Discord
       property afk_channel_id : Snowflake?
       property afk_timeout : Int32?
       property verification_level : UInt8
+      property premium_tier : UInt8
+      property premium_subscription_count : UInt8?
       property roles : Array(Role)
       @[JSON::Field(key: "emojis")]
       property emoji : Array(Emoji)

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -6,19 +6,19 @@ require "./guild"
 module Discord
   module Gateway
     struct ReadyPayload
-      JSON.mapping(
-        v: UInt8,
-        user: User,
-        private_channels: Array(PrivateChannel),
-        guilds: Array(UnavailableGuild),
-        session_id: String
-      )
+      include JSON::Serializable
+
+      property v : UInt8
+      property user : User
+      property private_channels : Array(PrivateChannel)
+      property guilds : Array(UnavailableGuild)
+      property session_id : String
     end
 
     struct ResumedPayload
-      JSON.mapping(
-        _trace: Array(String)
-      )
+      include JSON::Serializable
+
+      property _trace : Array(String)
     end
 
     struct IdentifyPacket
@@ -27,37 +27,42 @@ module Discord
         @d = IdentifyPayload.new(token, properties, large_threshold, compress, shard, intents)
       end
 
-      JSON.mapping(
-        op: Int32,
-        d: IdentifyPayload
-      )
+      include JSON::Serializable
+
+      property op : Int32
+      property d : IdentifyPayload
     end
 
     struct IdentifyPayload
       def initialize(@token, @properties, @compress, @large_threshold, @shard, @intents)
       end
 
-      JSON.mapping({
-        token:           String,
-        properties:      IdentifyProperties,
-        compress:        Bool,
-        large_threshold: Int32,
-        shard:           Tuple(Int32, Int32)?,
-        intents:         Intents?,
-      })
+      include JSON::Serializable
+
+      property token : String
+      property properties : IdentifyProperties
+      property compress : Bool
+      property large_threshold : Int32
+      property shard : Tuple(Int32, Int32)?
+      property intents : Intents?
     end
 
     struct IdentifyProperties
       def initialize(@os, @browser, @device, @referrer, @referring_domain)
       end
 
-      JSON.mapping(
-        os: {key: "$os", type: String},
-        browser: {key: "$browser", type: String},
-        device: {key: "$device", type: String},
-        referrer: {key: "$referrer", type: String},
-        referring_domain: {key: "$referring_domain", type: String}
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "$os")]
+      property os : String
+      @[JSON::Field(key: "$browser")]
+      property browser : String
+      @[JSON::Field(key: "$device")]
+      property device : String
+      @[JSON::Field(key: "$referrer")]
+      property referrer : String
+      @[JSON::Field(key: "$referring_domain")]
+      property referring_domain : String
     end
 
     @[Flags]
@@ -85,10 +90,10 @@ module Discord
         @d = ResumePayload.new(token, session_id, seq)
       end
 
-      JSON.mapping(
-        op: Int32,
-        d: ResumePayload
-      )
+      include JSON::Serializable
+
+      property op : Int32
+      property d : ResumePayload
     end
 
     # :nodoc:
@@ -96,11 +101,11 @@ module Discord
       def initialize(@token, @session_id, @seq)
       end
 
-      JSON.mapping(
-        token: String,
-        session_id: String,
-        seq: Int64
-      )
+      include JSON::Serializable
+
+      property token : String
+      property session_id : String
+      property seq : Int64
     end
 
     struct StatusUpdatePacket
@@ -109,10 +114,10 @@ module Discord
         @d = StatusUpdatePayload.new(status, game, afk, since)
       end
 
-      JSON.mapping(
-        op: Int32,
-        d: StatusUpdatePayload
-      )
+      include JSON::Serializable
+
+      property op : Int32
+      property d : StatusUpdatePayload
     end
 
     # :nodoc:
@@ -120,12 +125,15 @@ module Discord
       def initialize(@status, @game, @afk, @since)
       end
 
-      JSON.mapping(
-        status: {type: String?, emit_null: true},
-        game: {type: GamePlaying?, emit_null: true},
-        afk: Bool,
-        since: {type: Int64, nilable: true, emit_null: true}
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(emit_null: true)]
+      property status : String?
+      @[JSON::Field(emit_null: true)]
+      property game : GamePlaying?
+      property afk : Bool
+      @[JSON::Field(emit_null: true)]
+      property since : Int64?
     end
 
     struct VoiceStateUpdatePacket
@@ -134,10 +142,10 @@ module Discord
         @d = VoiceStateUpdatePayload.new(guild_id, channel_id, self_mute, self_deaf)
       end
 
-      JSON.mapping(
-        op: Int32,
-        d: VoiceStateUpdatePayload
-      )
+      include JSON::Serializable
+
+      property op : Int32
+      property d : VoiceStateUpdatePayload
     end
 
     # :nodoc:
@@ -145,12 +153,13 @@ module Discord
       def initialize(@guild_id, @channel_id, @self_mute, @self_deaf)
       end
 
-      JSON.mapping(
-        guild_id: UInt64,
-        channel_id: {type: UInt64?, emit_null: true},
-        self_mute: Bool,
-        self_deaf: Bool
-      )
+      include JSON::Serializable
+
+      property guild_id : UInt64
+      @[JSON::Field(emit_null: true)]
+      property channel_id : UInt64?
+      property self_mute : Bool
+      property self_deaf : Bool
     end
 
     struct RequestGuildMembersPacket
@@ -159,10 +168,10 @@ module Discord
         @d = RequestGuildMembersPayload.new(guild_id, query, limit)
       end
 
-      JSON.mapping(
-        op: Int32,
-        d: RequestGuildMembersPayload
-      )
+      include JSON::Serializable
+
+      property op : Int32
+      property d : RequestGuildMembersPayload
     end
 
     # :nodoc:
@@ -170,50 +179,49 @@ module Discord
       def initialize(@guild_id, @query, @limit)
       end
 
-      JSON.mapping(
-        guild_id: UInt64,
-        query: String,
-        limit: Int32
-      )
+      include JSON::Serializable
+
+      property guild_id : UInt64
+      property query : String
+      property limit : Int32
     end
 
     struct HelloPayload
-      JSON.mapping(
-        heartbeat_interval: UInt32,
-        _trace: Array(String)
-      )
+      include JSON::Serializable
+
+      property heartbeat_interval : UInt32
+      property _trace : Array(String)
     end
 
     # This one is special from simply Guild since it also has fields for members
     # and presences.
     struct GuildCreatePayload
-      JSON.mapping(
-        id: Snowflake,
-        name: String,
-        icon: String?,
-        splash: String?,
-        owner_id: Snowflake,
-        region: String,
-        afk_channel_id: Snowflake?,
-        afk_timeout: Int32?,
-        verification_level: UInt8,
-        premium_tier: UInt8,
-        premium_subscription_count: UInt8?,
-        roles: Array(Role),
-        emoji: {type: Array(Emoji), key: "emojis"},
-        features: Array(String),
-        large: Bool,
-        voice_states: Array(VoiceState),
-        unavailable: Bool?,
-        member_count: Int32,
-        members: Array(GuildMember),
-        channels: Array(Channel),
-        presences: Array(Presence),
-        widget_channel_id: Snowflake?,
-        default_message_notifications: UInt8,
-        explicit_content_filter: UInt8,
-        system_channel_id: Snowflake?
-      )
+      include JSON::Serializable
+
+      property id : Snowflake
+      property name : String
+      property icon : String?
+      property splash : String?
+      property owner_id : Snowflake
+      property region : String
+      property afk_channel_id : Snowflake?
+      property afk_timeout : Int32?
+      property verification_level : UInt8
+      property roles : Array(Role)
+      @[JSON::Field(key: "emojis")]
+      property emoji : Array(Emoji)
+      property features : Array(String)
+      property large : Bool
+      property voice_states : Array(VoiceState)
+      property unavailable : Bool?
+      property member_count : Int32
+      property members : Array(GuildMember)
+      property channels : Array(Channel)
+      property presences : Array(Presence)
+      property widget_channel_id : Snowflake?
+      property default_message_notifications : UInt8
+      property explicit_content_filter : UInt8
+      property system_channel_id : Snowflake?
 
       {% unless flag?(:correct_english) %}
         def emojis
@@ -223,24 +231,25 @@ module Discord
     end
 
     struct GuildDeletePayload
-      JSON.mapping(
-        id: Snowflake,
-        unavailable: Bool?
-      )
+      include JSON::Serializable
+
+      property id : Snowflake
+      property unavailable : Bool?
     end
 
     struct GuildBanPayload
-      JSON.mapping(
-        user: User,
-        guild_id: Snowflake
-      )
+      include JSON::Serializable
+
+      property user : User
+      property guild_id : Snowflake
     end
 
     struct GuildEmojiUpdatePayload
-      JSON.mapping(
-        guild_id: Snowflake,
-        emoji: {type: Array(Emoji), key: "emojis"}
-      )
+      include JSON::Serializable
+
+      property guild_id : Snowflake
+      @[JSON::Field(key: "emojis")]
+      property emoji : Array(Emoji)
 
       {% unless flag?(:correct_english) %}
         def emojis
@@ -250,187 +259,193 @@ module Discord
     end
 
     struct GuildIntegrationsUpdatePayload
-      JSON.mapping(
-        guild_id: Snowflake
-      )
+      include JSON::Serializable
+
+      property guild_id : Snowflake
     end
 
     struct GuildMemberAddPayload
-      JSON.mapping(
-        user: User,
-        nick: String?,
-        roles: Array(Snowflake),
-        joined_at: {type: Time?, converter: MaybeTimestampConverter},
-        premium_since: {type: Time?, converter: MaybeTimestampConverter},
-        deaf: Bool,
-        mute: Bool,
-        guild_id: Snowflake
-      )
+      include JSON::Serializable
+
+      property user : User
+      property nick : String?
+      property roles : Array(Snowflake)
+      @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+      property joined_at : Time?
+      @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+      property premium_since : Time?
+      property deaf : Bool
+      property mute : Bool
+      property guild_id : Snowflake
     end
 
     struct GuildMemberUpdatePayload
-      JSON.mapping(
-        user: User,
-        roles: Array(Snowflake),
-        nick: {type: String, nilable: true},
-        guild_id: Snowflake
-      )
+      include JSON::Serializable
+
+      property user : User
+      property roles : Array(Snowflake)
+      property nick : String?
+      property guild_id : Snowflake
     end
 
     struct GuildMemberRemovePayload
-      JSON.mapping(
-        user: User,
-        guild_id: Snowflake
-      )
+      include JSON::Serializable
+
+      property user : User
+      property guild_id : Snowflake
     end
 
     struct GuildMembersChunkPayload
-      JSON.mapping(
-        guild_id: Snowflake,
-        members: Array(GuildMember)
-      )
+      include JSON::Serializable
+
+      property guild_id : Snowflake
+      property members : Array(GuildMember)
     end
 
     struct GuildRolePayload
-      JSON.mapping(
-        guild_id: Snowflake,
-        role: Role
-      )
+      include JSON::Serializable
+
+      property guild_id : Snowflake
+      property role : Role
     end
 
     struct GuildRoleDeletePayload
-      JSON.mapping(
-        guild_id: Snowflake,
-        role_id: Snowflake
-      )
+      include JSON::Serializable
+
+      property guild_id : Snowflake
+      property role_id : Snowflake
     end
 
     struct InviteCreatePayload
-      JSON.mapping(
-        channel_id: Snowflake,
-        code: String,
-        created_at: {type: Time?, converter: MaybeTimestampConverter},
-        guild_id: Snowflake?,
-        inviter: User?,
-        max_age: Int32,
-        max_uses: Int32,
-        temporary: Bool,
-        uses: Int32
-      )
+      include JSON::Serializable
+
+      property channel_id : Snowflake
+      property code : String
+      @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+      property created_at : Time?
+      property guild_id : Snowflake?
+      property inviter : User?
+      property max_age : Int32
+      property max_uses : Int32
+      property temporary : Bool
+      property uses : Int32
     end
 
     struct InviteDeletePayload
-      JSON.mapping(
-        channel_id: Snowflake,
-        guild_id: Snowflake?,
-        code: String
-      )
+      include JSON::Serializable
+
+      property channel_id : Snowflake
+      property guild_id : Snowflake?
+      property code : String
     end
 
     struct MessageReactionPayload
-      JSON.mapping(
-        user_id: Snowflake,
-        channel_id: Snowflake,
-        message_id: Snowflake,
-        guild_id: Snowflake?,
-        emoji: ReactionEmoji
-      )
+      include JSON::Serializable
+
+      property user_id : Snowflake
+      property channel_id : Snowflake
+      property message_id : Snowflake
+      property guild_id : Snowflake?
+      property emoji : ReactionEmoji
     end
 
     struct MessageReactionRemoveAllPayload
-      JSON.mapping(
-        channel_id: Snowflake,
-        message_id: Snowflake,
-        guild_id: Snowflake?
-      )
+      include JSON::Serializable
+
+      property channel_id : Snowflake
+      property message_id : Snowflake
+      property guild_id : Snowflake?
     end
 
     struct MessageReactionRemoveEmojiPayload
-      JSON.mapping(
-        channel_id: Snowflake,
-        guild_id: Snowflake,
-        message_id: Snowflake,
-        emoji: ReactionEmoji
-      )
+      include JSON::Serializable
+
+      property channel_id : Snowflake
+      property guild_id : Snowflake
+      property message_id : Snowflake
+      property emoji : ReactionEmoji
     end
 
     struct MessageUpdatePayload
-      JSON.mapping(
-        type: UInt8?,
-        content: String?,
-        id: Snowflake,
-        channel_id: Snowflake,
-        guild_id: Snowflake?,
-        author: User?,
-        timestamp: {type: Time?, converter: MaybeTimestampConverter},
-        tts: Bool?,
-        mention_everyone: Bool?,
-        mentions: Array(User)?,
-        mention_roles: Array(Snowflake)?,
-        attachments: Array(Attachment)?,
-        embeds: Array(Embed)?,
-        pinned: Bool?
-      )
+      include JSON::Serializable
+
+      property type : UInt8?
+      property content : String?
+      property id : Snowflake
+      property channel_id : Snowflake
+      property guild_id : Snowflake?
+      property author : User?
+      @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+      property timestamp : Time?
+      property tts : Bool?
+      property mention_everyone : Bool?
+      property mentions : Array(User)?
+      property mention_roles : Array(Snowflake)?
+      property attachments : Array(Attachment)?
+      property embeds : Array(Embed)?
+      property pinned : Bool?
     end
 
     struct MessageDeletePayload
-      JSON.mapping(
-        id: Snowflake,
-        channel_id: Snowflake,
-        guild_id: Snowflake?
-      )
+      include JSON::Serializable
+
+      property id : Snowflake
+      property channel_id : Snowflake
+      property guild_id : Snowflake?
     end
 
     struct MessageDeleteBulkPayload
-      JSON.mapping(
-        ids: Array(Snowflake),
-        channel_id: Snowflake,
-        guild_id: Snowflake?
-      )
+      include JSON::Serializable
+
+      property ids : Array(Snowflake)
+      property channel_id : Snowflake
+      property guild_id : Snowflake?
     end
 
     struct PresenceUpdatePayload
-      JSON.mapping(
-        user: PartialUser,
-        roles: Array(Snowflake),
-        game: GamePlaying?,
-        nick: String?,
-        guild_id: Snowflake,
-        status: String,
-        activities: Array(GamePlaying)
-      )
+      include JSON::Serializable
+
+      property user : PartialUser
+      property roles : Array(Snowflake)
+      property game : GamePlaying?
+      property nick : String?
+      property guild_id : Snowflake
+      property status : String
+      property activities : Array(GamePlaying)
     end
 
     struct TypingStartPayload
-      JSON.mapping(
-        channel_id: Snowflake,
-        user_id: Snowflake,
-        guild_id: Snowflake?,
-        member: GuildMember?,
-        timestamp: {type: Time, converter: Time::EpochConverter}
-      )
+      include JSON::Serializable
+
+      property channel_id : Snowflake
+      property user_id : Snowflake
+      property guild_id : Snowflake?
+      property member : GuildMember?
+      @[JSON::Field(converter: Time::EpochConverter)]
+      property timestamp : Time
     end
 
     struct VoiceServerUpdatePayload
-      JSON.mapping(
-        token: String,
-        guild_id: Snowflake,
-        endpoint: String
-      )
+      include JSON::Serializable
+
+      property token : String
+      property guild_id : Snowflake
+      property endpoint : String
     end
 
     struct WebhooksUpdatePayload
-      JSON.mapping(
-        guild_id: Snowflake,
-        channel_id: Snowflake
-      )
+      include JSON::Serializable
+
+      property guild_id : Snowflake
+      property channel_id : Snowflake
     end
 
     struct ChannelPinsUpdatePayload
-      JSON.mapping(
-        last_pin_timestamp: {type: Time?, converter: MaybeTimestampConverter},
-        channel_id: Snowflake
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+      property last_pin_timestamp : Time?
+      property channel_id : Snowflake
     end
   end
 end

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -22,21 +22,18 @@ module Discord
     end
 
     struct IdentifyPacket
-      def initialize(token, properties, large_threshold, compress, shard, intents)
-        @op = Discord::Client::OP_IDENTIFY
-        @d = IdentifyPayload.new(token, properties, large_threshold, compress, shard, intents)
-      end
-
       include JSON::Serializable
 
       property op : Int32
       property d : IdentifyPayload
+
+      def initialize(token, properties, large_threshold, compress, shard, intents)
+        @op = Discord::Client::OP_IDENTIFY
+        @d = IdentifyPayload.new(token, properties, large_threshold, compress, shard, intents)
+      end
     end
 
     struct IdentifyPayload
-      def initialize(@token, @properties, @compress, @large_threshold, @shard, @intents)
-      end
-
       include JSON::Serializable
 
       property token : String
@@ -45,12 +42,12 @@ module Discord
       property large_threshold : Int32
       property shard : Tuple(Int32, Int32)?
       property intents : Intents?
+
+      def initialize(@token, @properties, @compress, @large_threshold, @shard, @intents)
+      end
     end
 
     struct IdentifyProperties
-      def initialize(@os, @browser, @device, @referrer, @referring_domain)
-      end
-
       include JSON::Serializable
 
       @[JSON::Field(key: "$os")]
@@ -63,6 +60,9 @@ module Discord
       property referrer : String
       @[JSON::Field(key: "$referring_domain")]
       property referring_domain : String
+
+      def initialize(@os, @browser, @device, @referrer, @referring_domain)
+      end
     end
 
     @[Flags]
@@ -85,46 +85,43 @@ module Discord
     end
 
     struct ResumePacket
-      def initialize(token, session_id, seq)
-        @op = Discord::Client::OP_RESUME
-        @d = ResumePayload.new(token, session_id, seq)
-      end
-
       include JSON::Serializable
 
       property op : Int32
       property d : ResumePayload
+
+      def initialize(token, session_id, seq)
+        @op = Discord::Client::OP_RESUME
+        @d = ResumePayload.new(token, session_id, seq)
+      end
     end
 
     # :nodoc:
     struct ResumePayload
-      def initialize(@token, @session_id, @seq)
-      end
-
       include JSON::Serializable
 
       property token : String
       property session_id : String
       property seq : Int64
+
+      def initialize(@token, @session_id, @seq)
+      end
     end
 
     struct StatusUpdatePacket
-      def initialize(status, game, afk, since)
-        @op = Discord::Client::OP_STATUS_UPDATE
-        @d = StatusUpdatePayload.new(status, game, afk, since)
-      end
-
       include JSON::Serializable
 
       property op : Int32
       property d : StatusUpdatePayload
+
+      def initialize(status, game, afk, since)
+        @op = Discord::Client::OP_STATUS_UPDATE
+        @d = StatusUpdatePayload.new(status, game, afk, since)
+      end
     end
 
     # :nodoc:
     struct StatusUpdatePayload
-      def initialize(@status, @game, @afk, @since)
-      end
-
       include JSON::Serializable
 
       @[JSON::Field(emit_null: true)]
@@ -134,25 +131,25 @@ module Discord
       property afk : Bool
       @[JSON::Field(emit_null: true)]
       property since : Int64?
+
+      def initialize(@status, @game, @afk, @since)
+      end
     end
 
     struct VoiceStateUpdatePacket
-      def initialize(guild_id, channel_id, self_mute, self_deaf)
-        @op = Discord::Client::OP_VOICE_STATE_UPDATE
-        @d = VoiceStateUpdatePayload.new(guild_id, channel_id, self_mute, self_deaf)
-      end
-
       include JSON::Serializable
 
       property op : Int32
       property d : VoiceStateUpdatePayload
+
+      def initialize(guild_id, channel_id, self_mute, self_deaf)
+        @op = Discord::Client::OP_VOICE_STATE_UPDATE
+        @d = VoiceStateUpdatePayload.new(guild_id, channel_id, self_mute, self_deaf)
+      end
     end
 
     # :nodoc:
     struct VoiceStateUpdatePayload
-      def initialize(@guild_id, @channel_id, @self_mute, @self_deaf)
-      end
-
       include JSON::Serializable
 
       property guild_id : UInt64
@@ -160,30 +157,33 @@ module Discord
       property channel_id : UInt64?
       property self_mute : Bool
       property self_deaf : Bool
+
+      def initialize(@guild_id, @channel_id, @self_mute, @self_deaf)
+      end
     end
 
     struct RequestGuildMembersPacket
-      def initialize(guild_id, query, limit)
-        @op = Discord::Client::OP_REQUEST_GUILD_MEMBERS
-        @d = RequestGuildMembersPayload.new(guild_id, query, limit)
-      end
-
       include JSON::Serializable
 
       property op : Int32
       property d : RequestGuildMembersPayload
+
+      def initialize(guild_id, query, limit)
+        @op = Discord::Client::OP_REQUEST_GUILD_MEMBERS
+        @d = RequestGuildMembersPayload.new(guild_id, query, limit)
+      end
     end
 
     # :nodoc:
     struct RequestGuildMembersPayload
-      def initialize(@guild_id, @query, @limit)
-      end
-
       include JSON::Serializable
 
       property guild_id : UInt64
       property query : String
       property limit : Int32
+
+      def initialize(@guild_id, @query, @limit)
+      end
     end
 
     struct HelloPayload

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -24,29 +24,30 @@ module Discord
       @system_channel_id = payload.system_channel_id
     end
 
-    JSON.mapping(
-      id: Snowflake,
-      name: String,
-      icon: String?,
-      splash: String?,
-      owner_id: Snowflake,
-      region: String,
-      afk_channel_id: Snowflake?,
-      afk_timeout: Int32?,
-      embed_enabled: Bool?,
-      embed_channel_id: Snowflake?,
-      verification_level: UInt8,
-      premium_tier: UInt8,
-      premium_subscription_count: UInt8?,
-      roles: Array(Role),
-      emoji: {type: Array(Emoji), key: "emojis"},
-      features: Array(String),
-      widget_enabled: {type: Bool, nilable: true},
-      widget_channel_id: Snowflake?,
-      default_message_notifications: UInt8,
-      explicit_content_filter: UInt8,
-      system_channel_id: Snowflake?
-    )
+    include JSON::Serializable
+
+    property id : Snowflake
+    property name : String
+    property icon : String?
+    property splash : String?
+    property owner_id : Snowflake
+    property region : String
+    property afk_channel_id : Snowflake?
+    property afk_timeout : Int32?
+    property embed_enabled : Bool?
+    property embed_channel_id : Snowflake?
+    property verification_level : UInt8
+    property premium_tier : UInt8
+    property premium_subscription_count : UInt8?
+    property roles : Array(Role)
+    @[JSON::Field(key: "emojis")]
+    property emoji : Array(Emoji)
+    property features : Array(String)
+    property widget_enabled : Bool?
+    property widget_channel_id : Snowflake?
+    property default_message_notifications : UInt8
+    property explicit_content_filter : UInt8
+    property system_channel_id : Snowflake?
 
     {% unless flag?(:correct_english) %}
       def emojis
@@ -74,17 +75,17 @@ module Discord
   end
 
   struct UnavailableGuild
-    JSON.mapping(
-      id: Snowflake,
-      unavailable: Bool
-    )
+    include JSON::Serializable
+
+    property id : Snowflake
+    property unavailable : Bool
   end
 
   struct GuildEmbed
-    JSON.mapping(
-      enabled: Bool,
-      channel_id: Snowflake?
-    )
+    include JSON::Serializable
+
+    property enabled : Bool
+    property channel_id : Snowflake?
   end
 
   struct GuildMember
@@ -125,15 +126,17 @@ module Discord
       # Presence updates have no joined_at or deaf/mute, thanks Discord
     end
 
-    JSON.mapping(
-      user: User,
-      nick: String?,
-      roles: Array(Snowflake),
-      joined_at: {type: Time?, converter: MaybeTimestampConverter},
-      premium_since: {type: Time?, converter: MaybeTimestampConverter},
-      deaf: Bool?,
-      mute: Bool?
-    )
+    include JSON::Serializable
+
+    property user : User
+    property nick : String?
+    property roles : Array(Snowflake)
+    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+    property joined_at : Time?
+    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+    property premium_since : Time?
+    property deaf : Bool?
+    property mute : Bool?
 
     # Produces a string to mention this member in a message
     def mention
@@ -146,30 +149,34 @@ module Discord
   end
 
   struct PartialGuildMember
-    JSON.mapping(
-      nick: String?,
-      roles: Array(Snowflake),
-      joined_at: {type: Time, converter: TimestampConverter},
-      premium_since: {type: Time?, converter: MaybeTimestampConverter},
-      deaf: Bool,
-      mute: Bool
-    )
+    include JSON::Serializable
+
+    property nick : String?
+    property roles : Array(Snowflake)
+    @[JSON::Field(converter: Discord::TimestampConverter)]
+    property joined_at : Time
+    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+    property premium_since : Time?
+    property deaf : Bool
+    property mute : Bool
   end
 
   struct Integration
-    JSON.mapping(
-      id: Snowflake,
-      name: String,
-      type: String,
-      enabled: Bool,
-      syncing: Bool,
-      role_id: Snowflake,
-      expire_behaviour: {type: UInt8, key: "expire_behavior"},
-      expire_grace_period: Int32,
-      user: User,
-      account: IntegrationAccount,
-      synced_at: {type: Time, converter: Time::EpochConverter}
-    )
+    include JSON::Serializable
+
+    property id : Snowflake
+    property name : String
+    property type : String
+    property enabled : Bool
+    property syncing : Bool
+    property role_id : Snowflake
+    @[JSON::Field(key: "expire_behavior")]
+    property expire_behaviour : UInt8
+    property expire_grace_period : Int32
+    property user : User
+    property account : IntegrationAccount
+    @[JSON::Field(converter: Time::EpochConverter)]
+    property synced_at : Time
 
     {% unless flag?(:correct_english) %}
       def expire_behavior
@@ -179,21 +186,21 @@ module Discord
   end
 
   struct IntegrationAccount
-    JSON.mapping(
-      id: String,
-      name: String
-    )
+    include JSON::Serializable
+
+    property id : String
+    property name : String
   end
 
   struct Emoji
-    JSON.mapping(
-      id: Snowflake?,
-      name: String,
-      roles: Array(Snowflake)?,
-      require_colons: Bool?,
-      managed: Bool?,
-      animated: Bool?
-    )
+    include JSON::Serializable
+
+    property id : Snowflake?
+    property name : String
+    property roles : Array(Snowflake)?
+    property require_colons : Bool?
+    property managed : Bool?
+    property animated : Bool?
 
     # Produces a CDN URL to this emoji's image in the given `size`. Will return
     # a PNG, or GIF if the emoji is animated.
@@ -224,16 +231,17 @@ module Discord
   end
 
   struct Role
-    JSON.mapping(
-      id: Snowflake,
-      name: String,
-      permissions: Permissions,
-      colour: {type: UInt32, key: "color"},
-      hoist: Bool,
-      position: Int32,
-      managed: Bool,
-      mentionable: Bool
-    )
+    include JSON::Serializable
+
+    property id : Snowflake
+    property name : String
+    property permissions : Permissions
+    @[JSON::Field(key: "color")]
+    property colour : UInt32
+    property hoist : Bool
+    property position : Int32
+    property managed : Bool
+    property mentionable : Bool
 
     {% unless flag?(:correct_english) %}
       def color
@@ -248,10 +256,10 @@ module Discord
   end
 
   struct GuildBan
-    JSON.mapping(
-      user: User,
-      reason: String?
-    )
+    include JSON::Serializable
+
+    property user : User
+    property reason : String?
   end
 
   struct GamePlaying
@@ -266,21 +274,21 @@ module Discord
       Custom    = 4
     end
 
-    JSON.mapping(
-      name: String?,
-      type: Type?,
-      url: String?,
-      state: String?,
-      emoji: Emoji?
-    )
+    include JSON::Serializable
+
+    property name : String?
+    property type : Type?
+    property url : String?
+    property state : String?
+    property emoji : Emoji?
   end
 
   struct Presence
-    JSON.mapping(
-      user: PartialUser,
-      game: GamePlaying?,
-      status: String,
-      activities: Array(GamePlaying)
-    )
+    include JSON::Serializable
+
+    property user : PartialUser
+    property game : GamePlaying?
+    property status : String
+    property activities : Array(GamePlaying)
   end
 end

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -3,27 +3,6 @@ require "./voice"
 
 module Discord
   struct Guild
-    # :nodoc:
-    def initialize(payload : Gateway::GuildCreatePayload)
-      @id = payload.id
-      @name = payload.name
-      @icon = payload.icon
-      @splash = payload.splash
-      @owner_id = payload.owner_id
-      @region = payload.region
-      @afk_channel_id = payload.afk_channel_id
-      @afk_timeout = payload.afk_timeout
-      @verification_level = payload.verification_level
-      @premium_tier = payload.premium_tier
-      @roles = payload.roles
-      @emoji = payload.emoji
-      @features = payload.features
-      @widget_channel_id = payload.widget_channel_id
-      @default_message_notifications = payload.default_message_notifications
-      @explicit_content_filter = payload.explicit_content_filter
-      @system_channel_id = payload.system_channel_id
-    end
-
     include JSON::Serializable
 
     property id : Snowflake
@@ -48,6 +27,27 @@ module Discord
     property default_message_notifications : UInt8
     property explicit_content_filter : UInt8
     property system_channel_id : Snowflake?
+
+    # :nodoc:
+    def initialize(payload : Gateway::GuildCreatePayload)
+      @id = payload.id
+      @name = payload.name
+      @icon = payload.icon
+      @splash = payload.splash
+      @owner_id = payload.owner_id
+      @region = payload.region
+      @afk_channel_id = payload.afk_channel_id
+      @afk_timeout = payload.afk_timeout
+      @verification_level = payload.verification_level
+      @premium_tier = payload.premium_tier
+      @roles = payload.roles
+      @emoji = payload.emoji
+      @features = payload.features
+      @widget_channel_id = payload.widget_channel_id
+      @default_message_notifications = payload.default_message_notifications
+      @explicit_content_filter = payload.explicit_content_filter
+      @system_channel_id = payload.system_channel_id
+    end
 
     {% unless flag?(:correct_english) %}
       def emojis
@@ -89,6 +89,18 @@ module Discord
   end
 
   struct GuildMember
+    include JSON::Serializable
+
+    property user : User
+    property nick : String?
+    property roles : Array(Snowflake)
+    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+    property joined_at : Time?
+    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+    property premium_since : Time?
+    property deaf : Bool?
+    property mute : Bool?
+
     # :nodoc:
     def initialize(user : User, partial_member : PartialGuildMember)
       @user = user
@@ -125,18 +137,6 @@ module Discord
       @roles = payload.roles
       # Presence updates have no joined_at or deaf/mute, thanks Discord
     end
-
-    include JSON::Serializable
-
-    property user : User
-    property nick : String?
-    property roles : Array(Snowflake)
-    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
-    property joined_at : Time?
-    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
-    property premium_since : Time?
-    property deaf : Bool?
-    property mute : Bool?
 
     # Produces a string to mention this member in a message
     def mention
@@ -263,8 +263,7 @@ module Discord
   end
 
   struct GamePlaying
-    def initialize(@name = nil, @type : Type? = nil, @url = nil, @state = nil, @emoji = nil)
-    end
+    include JSON::Serializable
 
     enum Type : UInt8
       Playing   = 0
@@ -274,13 +273,20 @@ module Discord
       Custom    = 4
     end
 
-    include JSON::Serializable
-
     property name : String?
     property type : Type?
     property url : String?
     property state : String?
     property emoji : Emoji?
+
+    def initialize(
+      @name = nil,
+      @type : Type? = nil,
+      @url = nil,
+      @state = nil,
+      @emoji = nil
+    )
+    end
   end
 
   struct Presence

--- a/src/discordcr/mappings/invite.cr
+++ b/src/discordcr/mappings/invite.cr
@@ -3,41 +3,42 @@ require "./user"
 
 module Discord
   struct Invite
-    JSON.mapping(
-      code: String,
-      guild: InviteGuild,
-      channel: InviteChannel
-    )
+    include JSON::Serializable
+
+    property code : String
+    property guild : InviteGuild
+    property channel : InviteChannel
   end
 
   struct InviteMetadata
-    JSON.mapping(
-      code: String,
-      guild: InviteGuild,
-      channel: InviteChannel,
-      inviter: User,
-      users: UInt32,
-      max_uses: UInt32,
-      max_age: UInt32,
-      temporary: Bool,
-      created_at: {type: Time, converter: TimestampConverter},
-      revoked: Bool
-    )
+    include JSON::Serializable
+
+    property code : String
+    property guild : InviteGuild
+    property channel : InviteChannel
+    property inviter : User
+    property users : UInt32
+    property max_uses : UInt32
+    property max_age : UInt32
+    property temporary : Bool
+    @[JSON::Field(converter: Discord::TimestampConverter)]
+    property created_at : Time
+    property revoked : Bool
   end
 
   struct InviteGuild
-    JSON.mapping(
-      id: Snowflake,
-      name: String,
-      splash_hash: String?
-    )
+    include JSON::Serializable
+
+    property id : Snowflake
+    property name : String
+    property splash_hash : String?
   end
 
   struct InviteChannel
-    JSON.mapping(
-      id: Snowflake,
-      name: String,
-      type: UInt8
-    )
+    include JSON::Serializable
+
+    property id : Snowflake
+    property name : String
+    property type : UInt8
   end
 end

--- a/src/discordcr/mappings/oauth2.cr
+++ b/src/discordcr/mappings/oauth2.cr
@@ -6,23 +6,23 @@ module Discord
   # information about a `Client`'s associated bot user account and owner,
   # among other OAuth2 properties.
   struct OAuth2Application
-    JSON.mapping({
-      id:                     Snowflake,
-      name:                   String,
-      icon:                   String?,
-      description:            String?,
-      rpc_origins:            Array(String)?,
-      bot_public:             Bool,
-      bot_require_code_grant: Bool,
-      owner:                  User,
-      summary:                String,
-      verify_key:             String,
-      team:                   Team?,
-      guild_id:               Snowflake?,
-      primary_sku_id:         String?,
-      slug:                   String?,
-      cover_image:            String?,
-    })
+    include JSON::Serializable
+
+    property id : Snowflake
+    property name : String
+    property icon : String?
+    property description : String?
+    property rpc_origins : Array(String)?
+    property bot_public : Bool
+    property bot_require_code_grant : Bool
+    property owner : User
+    property summary : String
+    property verify_key : String
+    property team : Team?
+    property guild_id : Snowflake?
+    property primary_sku_id : String?
+    property slug : String?
+    property cover_image : String?
 
     # Produces a CDN URL for this application's icon in the given `format` and `size`
     def icon_url(format : CDN::ApplicationIconFormat = CDN::ApplicationIconFormat::WebP,
@@ -34,21 +34,21 @@ module Discord
   end
 
   struct Team
-    JSON.mapping({
-      icon:          String?,
-      id:            Snowflake,
-      members:       Array(TeamMember),
-      owner_user_id: Snowflake,
-    })
+    include JSON::Serializable
+
+    property icon : String?
+    property id : Snowflake
+    property members : Array(TeamMember)
+    property owner_user_id : Snowflake
   end
 
   struct TeamMember
-    JSON.mapping({
-      membership_state: TeamMembershipState,
-      permissions:      Array(String),
-      team_id:          Snowflake,
-      user:             User,
-    })
+    include JSON::Serializable
+
+    property membership_state : TeamMembershipState
+    property permissions : Array(String)
+    property team_id : Snowflake
+    property user : User
   end
 
   enum TeamMembershipState : UInt8

--- a/src/discordcr/mappings/rest.cr
+++ b/src/discordcr/mappings/rest.cr
@@ -4,41 +4,42 @@ module Discord
   module REST
     # A response to the Get Gateway REST API call.
     struct GatewayResponse
-      JSON.mapping(
-        url: String
-      )
+      include JSON::Serializable
+
+      property url : String
     end
 
     # A response to the Get Gateway Bot REST API call.
     struct GatewayBotResponse
-      JSON.mapping(
-        url: String,
-        shards: Int32,
-        session_start_limit: SessionStartLimit
-      )
+      include JSON::Serializable
+
+      property url : String
+      property shards : Int32
+      property session_start_limit : SessionStartLimit
     end
 
     # Session start limit details included in the Get Gateway Bot REST API call.
     struct SessionStartLimit
-      JSON.mapping(
-        total: Int32,
-        remaining: Int32,
-        reset_after: {type: Time::Span, converter: TimeSpanMillisecondsConverter}
-      )
+      include JSON::Serializable
+
+      property total : Int32
+      property remaining : Int32
+      @[JSON::Field(converter: Discord::TimeSpanMillisecondsConverter)]
+      property reset_after : Time::Span
     end
 
     # A response to the Get Guild Prune Count REST API call.
     struct PruneCountResponse
-      JSON.mapping(
-        pruned: UInt32
-      )
+      include JSON::Serializable
+
+      property pruned : UInt32
     end
 
     # A response to the Get Guild Vanity URL REST API call.
     struct GuildVanityURLResponse
-      JSON.mapping(
-        code: String
-      )
+      include JSON::Serializable
+
+      property code : String
     end
 
     # A request payload to rearrange channels in a `Guild` by a REST API call.
@@ -74,10 +75,10 @@ module Discord
 
     # A request payload to rearrange roles in a `Guild` by a REST API call.
     struct ModifyRolePositionPayload
-      JSON.mapping(
-        id: Snowflake,
-        position: Int32
-      )
+      include JSON::Serializable
+
+      property id : Snowflake
+      property position : Int32
 
       def initialize(id : UInt64 | Snowflake, @position : Int32)
         id = Snowflake.new(id) unless id.is_a?(Snowflake)

--- a/src/discordcr/mappings/user.cr
+++ b/src/discordcr/mappings/user.cr
@@ -12,19 +12,19 @@ module Discord
       @bot = partial.bot
     end
 
-    JSON.mapping(
-      username: String,
-      id: Snowflake,
-      discriminator: String,
-      avatar: String?,
-      email: String?,
-      bot: Bool?,
-      system: Bool?,
-      mfa_enabled: Bool?,
-      verified: Bool?,
-      member: PartialGuildMember?,
-      flags: UserFlags?,
-    )
+    include JSON::Serializable
+
+    property username : String
+    property id : Snowflake
+    property discriminator : String
+    property avatar : String?
+    property email : String?
+    property bot : Bool?
+    property system : Bool?
+    property mfa_enabled : Bool?
+    property verified : Bool?
+    property member : PartialGuildMember?
+    property flags : UserFlags?
 
     # Produces a CDN URL to this user's avatar in the given `size`.
     # If the user has an avatar a WebP will be returned, or a GIF
@@ -76,14 +76,14 @@ module Discord
   end
 
   struct PartialUser
-    JSON.mapping(
-      username: String?,
-      id: Snowflake,
-      discriminator: String?,
-      avatar: String?,
-      email: String?,
-      bot: Bool?
-    )
+    include JSON::Serializable
+
+    property username : String?
+    property id : Snowflake
+    property discriminator : String?
+    property avatar : String?
+    property email : String?
+    property bot : Bool?
 
     def full? : Bool
       !@username.nil? && !@discriminator.nil? && !@avatar.nil?
@@ -91,21 +91,21 @@ module Discord
   end
 
   struct UserGuild
-    JSON.mapping(
-      id: Snowflake,
-      name: String,
-      icon: String?,
-      owner: Bool,
-      permissions: Permissions
-    )
+    include JSON::Serializable
+
+    property id : Snowflake
+    property name : String
+    property icon : String?
+    property owner : Bool
+    property permissions : Permissions
   end
 
   struct Connection
-    JSON.mapping(
-      id: Snowflake,
-      name: String,
-      type: String,
-      revoked: Bool
-    )
+    include JSON::Serializable
+
+    property id : Snowflake
+    property name : String
+    property type : String
+    property revoked : Bool
   end
 end

--- a/src/discordcr/mappings/user.cr
+++ b/src/discordcr/mappings/user.cr
@@ -2,16 +2,6 @@ require "./converters"
 
 module Discord
   struct User
-    # :nodoc:
-    def initialize(partial : PartialUser)
-      @username = partial.username.not_nil!
-      @id = partial.id
-      @discriminator = partial.discriminator.not_nil!
-      @avatar = partial.avatar
-      @email = partial.email
-      @bot = partial.bot
-    end
-
     include JSON::Serializable
 
     property username : String
@@ -25,6 +15,16 @@ module Discord
     property verified : Bool?
     property member : PartialGuildMember?
     property flags : UserFlags?
+
+    # :nodoc:
+    def initialize(partial : PartialUser)
+      @username = partial.username.not_nil!
+      @id = partial.id
+      @discriminator = partial.discriminator.not_nil!
+      @avatar = partial.avatar
+      @email = partial.email
+      @bot = partial.bot
+    end
 
     # Produces a CDN URL to this user's avatar in the given `size`.
     # If the user has an avatar a WebP will be returned, or a GIF

--- a/src/discordcr/mappings/voice.cr
+++ b/src/discordcr/mappings/voice.cr
@@ -2,29 +2,29 @@ require "./converters"
 
 module Discord
   struct VoiceState
-    JSON.mapping(
-      guild_id: Snowflake?,
-      channel_id: Snowflake?,
-      user_id: Snowflake,
-      member: GuildMember?,
-      session_id: String,
-      deaf: Bool,
-      mute: Bool,
-      self_deaf: Bool,
-      self_mute: Bool,
-      suppress: Bool
-    )
+    include JSON::Serializable
+
+    property guild_id : Snowflake?
+    property channel_id : Snowflake?
+    property user_id : Snowflake
+    property member : GuildMember?
+    property session_id : String
+    property deaf : Bool
+    property mute : Bool
+    property self_deaf : Bool
+    property self_mute : Bool
+    property suppress : Bool
   end
 
   struct VoiceRegion
-    JSON.mapping(
-      id: String,
-      name: String,
-      sample_hostname: String,
-      sample_port: UInt16,
-      custom: Bool?,
-      vip: Bool,
-      optimal: Bool
-    )
+    include JSON::Serializable
+
+    property id : String
+    property name : String
+    property sample_hostname : String
+    property sample_port : UInt16
+    property custom : Bool?
+    property vip : Bool
+    property optimal : Bool
   end
 end

--- a/src/discordcr/mappings/vws.cr
+++ b/src/discordcr/mappings/vws.cr
@@ -9,22 +9,22 @@ module Discord
         @d = IdentifyPayload.new(server_id, user_id, session_id, token)
       end
 
-      JSON.mapping(
-        op: Int32,
-        d: IdentifyPayload
-      )
+      include JSON::Serializable
+
+      property op : Int32
+      property d : IdentifyPayload
     end
 
     struct IdentifyPayload
       def initialize(@server_id, @user_id, @session_id, @token)
       end
 
-      JSON.mapping(
-        server_id: UInt64,
-        user_id: UInt64,
-        session_id: String,
-        token: String
-      )
+      include JSON::Serializable
+
+      property server_id : UInt64
+      property user_id : UInt64
+      property session_id : String
+      property token : String
     end
 
     struct SelectProtocolPacket
@@ -33,47 +33,47 @@ module Discord
         @d = SelectProtocolPayload.new(protocol, data)
       end
 
-      JSON.mapping(
-        op: Int32,
-        d: SelectProtocolPayload
-      )
+      include JSON::Serializable
+
+      property op : Int32
+      property d : SelectProtocolPayload
     end
 
     struct SelectProtocolPayload
       def initialize(@protocol, @data)
       end
 
-      JSON.mapping(
-        protocol: String,
-        data: ProtocolData
-      )
+      include JSON::Serializable
+
+      property protocol : String
+      property data : ProtocolData
     end
 
     struct ProtocolData
       def initialize(@address, @port, @mode)
       end
 
-      JSON.mapping(
-        address: String,
-        port: UInt16,
-        mode: String
-      )
+      include JSON::Serializable
+
+      property address : String
+      property port : UInt16
+      property mode : String
     end
 
     struct ReadyPayload
-      JSON.mapping(
-        ssrc: Int32,
-        port: Int32,
-        modes: Array(String),
-        ip: String
-      )
+      include JSON::Serializable
+
+      property ssrc : Int32
+      property port : Int32
+      property modes : Array(String)
+      property ip : String
     end
 
     struct SessionDescriptionPayload
-      JSON.mapping(
-        secret_key: Array(UInt8),
-        mode: String
-      )
+      include JSON::Serializable
+
+      property secret_key : Array(UInt8)
+      property mode : String
     end
 
     struct SpeakingPacket
@@ -82,26 +82,26 @@ module Discord
         @d = SpeakingPayload.new(speaking, delay)
       end
 
-      JSON.mapping(
-        op: Int32,
-        d: SpeakingPayload
-      )
+      include JSON::Serializable
+
+      property op : Int32
+      property d : SpeakingPayload
     end
 
     struct SpeakingPayload
       def initialize(@speaking, @delay)
       end
 
-      JSON.mapping(
-        speaking: Bool,
-        delay: Int32
-      )
+      include JSON::Serializable
+
+      property speaking : Bool
+      property delay : Int32
     end
 
     struct HelloPayload
-      JSON.mapping(
-        heartbeat_interval: Float32
-      )
+      include JSON::Serializable
+
+      property heartbeat_interval : Float32
     end
   end
 end

--- a/src/discordcr/mappings/vws.cr
+++ b/src/discordcr/mappings/vws.cr
@@ -4,60 +4,60 @@ module Discord
   # :nodoc:
   module VWS
     struct IdentifyPacket
-      def initialize(server_id, user_id, session_id, token)
-        @op = Discord::VoiceClient::OP_IDENTIFY
-        @d = IdentifyPayload.new(server_id, user_id, session_id, token)
-      end
-
       include JSON::Serializable
 
       property op : Int32
       property d : IdentifyPayload
+
+      def initialize(server_id, user_id, session_id, token)
+        @op = Discord::VoiceClient::OP_IDENTIFY
+        @d = IdentifyPayload.new(server_id, user_id, session_id, token)
+      end
     end
 
     struct IdentifyPayload
-      def initialize(@server_id, @user_id, @session_id, @token)
-      end
-
       include JSON::Serializable
 
       property server_id : UInt64
       property user_id : UInt64
       property session_id : String
       property token : String
+
+      def initialize(@server_id, @user_id, @session_id, @token)
+      end
     end
 
     struct SelectProtocolPacket
-      def initialize(protocol, data)
-        @op = Discord::VoiceClient::OP_SELECT_PROTOCOL
-        @d = SelectProtocolPayload.new(protocol, data)
-      end
-
       include JSON::Serializable
 
       property op : Int32
       property d : SelectProtocolPayload
+
+      def initialize(protocol, data)
+        @op = Discord::VoiceClient::OP_SELECT_PROTOCOL
+        @d = SelectProtocolPayload.new(protocol, data)
+      end
     end
 
     struct SelectProtocolPayload
-      def initialize(@protocol, @data)
-      end
-
       include JSON::Serializable
 
       property protocol : String
       property data : ProtocolData
+
+      def initialize(@protocol, @data)
+      end
     end
 
     struct ProtocolData
-      def initialize(@address, @port, @mode)
-      end
-
       include JSON::Serializable
 
       property address : String
       property port : UInt16
       property mode : String
+
+      def initialize(@address, @port, @mode)
+      end
     end
 
     struct ReadyPayload
@@ -77,25 +77,25 @@ module Discord
     end
 
     struct SpeakingPacket
-      def initialize(speaking, delay)
-        @op = Discord::VoiceClient::OP_SPEAKING
-        @d = SpeakingPayload.new(speaking, delay)
-      end
-
       include JSON::Serializable
 
       property op : Int32
       property d : SpeakingPayload
+
+      def initialize(speaking, delay)
+        @op = Discord::VoiceClient::OP_SPEAKING
+        @d = SpeakingPayload.new(speaking, delay)
+      end
     end
 
     struct SpeakingPayload
-      def initialize(@speaking, @delay)
-      end
-
       include JSON::Serializable
 
       property speaking : Bool
       property delay : Int32
+
+      def initialize(@speaking, @delay)
+      end
     end
 
     struct HelloPayload

--- a/src/discordcr/mappings/webhook.cr
+++ b/src/discordcr/mappings/webhook.cr
@@ -3,14 +3,14 @@ require "./user"
 
 module Discord
   struct Webhook
-    JSON.mapping(
-      id: Snowflake,
-      guild_id: Snowflake?,
-      channel_id: Snowflake,
-      user: User?,
-      name: String,
-      avatar: String?,
-      token: String
-    )
+    include JSON::Serializable
+
+    property id : Snowflake
+    property guild_id : Snowflake?
+    property channel_id : Snowflake
+    property user : User?
+    property name : String
+    property avatar : String?
+    property token : String
   end
 end


### PR DESCRIPTION
> Warning: Deprecated JSON.mapping. use JSON::Serializable instead (the legacy behaviour is also available in a shard at github:crystal-lang/json_mapping.cr)

Main part of work was performed with automatic Ruby script, ~6 months ago, so review carefully. Pay attention to data types and amount of fields

https://crystal-lang.org/api/0.35.1/JSON/Serializable.html