### PR TITLE
fix: voice ws connection

### DIFF
--- a/src/discordcr/voice.cr
+++ b/src/discordcr/voice.cr
@@ -45,17 +45,20 @@ module Discord
     # received as part of the gateway READY dispatch, for example)
     def initialize(payload : Discord::Gateway::VoiceServerUpdatePayload,
                    session : Discord::Gateway::Session, user_id : UInt64 | Snowflake)
-      @user_id = user_id.to_u64
-      @endpoint = payload.endpoint.gsub(":80", "")
+      initialize(payload.endpoint, payload.token, session.session_id, payload.guild_id, user_id)
+    end
 
-      @server_id = payload.guild_id.to_u64
-      @session_id = session.session_id
-      @token = payload.token
+    # :nodoc:
+    def initialize(@endpoint, @token, @session_id, guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake)
+      @user_id = user_id.to_u64
+      host, port = @endpoint.split(':')
+
+      @server_id = guild_id.to_u64
 
       @websocket = Discord::WebSocket.new(
-        host: @endpoint,
+        host: host,
         path: "/?v=4",
-        port: 443,
+        port: port.to_i,
         tls: true
       )
 

--- a/src/discordcr/websocket.cr
+++ b/src/discordcr/websocket.cr
@@ -60,7 +60,7 @@ module Discord
 
     def initialize(@host : String, @path : String, @port : Int32, @tls : Bool,
                    @zlib_buffer_size : Int32 = 10 * 1024 * 1024)
-      Log.info { "Connecting to #{@host}#{@path}:#{@port}" }
+      Log.info { "Connecting to #{@host}:#{@port}#{@path}" }
       @websocket = HTTP::WebSocket.new(
         host: @host,
         path: @path,


### PR DESCRIPTION
This PR fixes error while establishing vws (it can be easily reproduced in `examples/voice_send.cr`)
Log with error:
```
2021-01-04T10:57:50.694115Z   INFO - discord.ws: Connecting to russia3452.discord.media:443/?v=4:443
Hostname lookup for russia3452.discord.media:443 failed: No address found (Socket::Addrinfo::Error)
  from ../../../../usr/share/crystal/src/socket/addrinfo.cr:125:12 in 'initialize'
  from ../../../../usr/share/crystal/src/socket/tcp_socket.cr:27:3 in 'initialize'
  from ../../../../usr/share/crystal/src/socket/tcp_socket.cr:27:3 in 'new'
  from ../../../../usr/share/crystal/src/http/web_socket/protocol.cr:273:5 in 'new'
  from ../../../../usr/share/crystal/src/http/web_socket.cr:48:5 in 'new:host:path:port:tls'
  from src/discordcr/websocket.cr:64:20 in 'initialize:host:path:port:tls'
  from src/discordcr/websocket.cr:61:5 in 'new:host:path:port:tls'
  from src/discordcr/voice.cr:55:20 in 'initialize'
  from src/discordcr/voice.cr:46:5 in 'new'
  from examples/voice_send.cr:133:25 in '->'
  from ../../../../usr/share/crystal/src/primitives.cr:255:3 in 'handle_dispatch'
  from src/discordcr/client.cr:235:13 in '->'
  from ../../../../usr/share/crystal/src/primitives.cr:255:3 in 'run'
  from ../../../../usr/share/crystal/src/fiber.cr:92:34 in '->'
  from ???
```

Previously we were just getting rid of `:80` in `endpoint` and forcing port `443`. Now code failes since Discord sends endpoint which looks something like this: `russia3452.discord.media:443`

---

Regarding addition of separate `initialize` method:
At some point I thought about creating something like lavalink while reusing already existing code. This would require initialize method which would accept raw data. This addition is pretty much optional and currently have no application in lib, yeeeeah .-.