### PR TITLE
Enum serialization fix

### DIFF
--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -74,6 +74,10 @@ module Discord
     def self.new(pull : JSON::PullParser)
       ChannelType.new(pull.read_int.to_u8)
     end
+
+    def to_json(json : JSON::Builder)
+      json.number(value)
+    end
   end
 
   struct Channel

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -274,6 +274,7 @@ module Discord
     end
 
     property name : String?
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::GamePlaying::Type))]
     property type : Type?
     property url : String?
     property state : String?

--- a/src/discordcr/mappings/permissions.cr
+++ b/src/discordcr/mappings/permissions.cr
@@ -35,5 +35,9 @@ module Discord
     def self.new(pull : JSON::PullParser)
       Permissions.new(pull.read_int.to_u64)
     end
+
+    def to_json(json : JSON::Builder)
+      json.number(value)
+    end
   end
 end


### PR DESCRIPTION
Resolves #10.
discordcr already serializes enums from JSON without problem, so it just needed few changes when serializing enums to JSON.
I tried to make use of ValueConverter in some places, but ended up just overriding `#to_json` instead.
Please feel free to point out if I missed anything!