### PR TITLE
Implement new stage channels and instances

### DIFF
--- a/src/discordcr/cache.cr
+++ b/src/discordcr/cache.cr
@@ -138,7 +138,7 @@ module Discord
       @roles[id.to_u64] # There is no endpoint for getting an individual role, so we will have to ignore that case for now.
     end
 
-    # Resolves a Stage instance by its **ID**.
+    # Resolves a Stage instance by its *ID*.
     # An API request will be performed if the object is not cached.
     def resolve_stage_instance(id : UInt64 | Snowflake) : StageInstance
       id = id.to_u64

--- a/src/discordcr/cache.cr
+++ b/src/discordcr/cache.cr
@@ -47,6 +47,10 @@ module Discord
     # affected guilds would be missing here too.
     getter guilds
 
+    # A map of cached stage instances, i. e. all stage instances on all servers
+    # the bot is on.
+    getter stage_instances
+
     # A double map of members on servers, represented as {guild ID => {user ID
     # => member}}. Will only contain previously and currently online members as
     # well as all members that have been chunked (see
@@ -69,6 +73,10 @@ module Discord
     # [channel IDs]}.
     getter guild_channels
 
+    # Mapping of guilds to the Stage instances on them, represented as {guild ID =>
+    # [stage instance IDs]}.
+    getter guild_stage_instances
+
     # Mapping of users in guild to voice states, represented as {guild ID =>
     # {user ID => voice state}}
     getter voice_states
@@ -81,11 +89,13 @@ module Discord
       @guilds = Hash(UInt64, Guild).new
       @members = Hash(UInt64, Hash(UInt64, GuildMember)).new
       @roles = Hash(UInt64, Role).new
+      @stage_instances = Hash(UInt64, StageInstance).new
 
       @dm_channels = Hash(UInt64, UInt64).new
 
       @guild_roles = Hash(UInt64, Array(UInt64)).new
       @guild_channels = Hash(UInt64, Array(UInt64)).new
+      @guild_stage_instances = Hash(UInt64, Array(UInt64)).new
 
       @voice_states = Hash(UInt64, Hash(UInt64, VoiceState)).new
     end
@@ -128,6 +138,13 @@ module Discord
       @roles[id.to_u64] # There is no endpoint for getting an individual role, so we will have to ignore that case for now.
     end
 
+    # Resolves a Stage instance by its **ID**.
+    # An API request will be performed if the object is not cached.
+    def resolve_stage_instance(id : UInt64 | Snowflake) : StageInstance
+      id = id.to_u64
+      @stage_instances.fetch(id) { @stage_instances[id] = @client.get_stage_instance(id) }
+    end
+
     # Resolves the ID of a DM channel with a particular user by the recipient's
     # *recipient_id*. If there is no such channel cached, one will be created.
     def resolve_dm_channel(recipient_id : UInt64 | Snowflake) : UInt64
@@ -166,6 +183,11 @@ module Discord
     # Deletes a guild from the cache given its *ID*.
     def delete_guild(id : UInt64 | Snowflake)
       @guilds.delete(id.to_u64)
+    end
+
+    # Deletes a stage instance from the cache given its *ID*.
+    def delete_stage_instance(id : UInt64 | Snowflake)
+      @stage_instances.delete(id.to_u64)
     end
 
     # Deletes a member from the cache given its *user_id* and the *guild_id* it
@@ -223,6 +245,11 @@ module Discord
     # Adds a specific *role* to the cache.
     def cache(role : Role)
       @roles[role.id.to_u64] = role
+    end
+
+    # Adds a specific *Stage instance* to the cache.
+    def cache(stage_instance : StageInstance)
+      @stage_instances[stage_instance.id.to_u64] = stage_instance
     end
 
     # Adds a specific *voice state* to the cache.
@@ -295,6 +322,27 @@ module Discord
       guild_id = guild_id.to_u64
       channel_id = channel_id.to_u64
       @guild_channels[guild_id]?.try { |local_channels| local_channels.delete(channel_id) }
+    end
+
+    # Returns all Stage instances of a guild, identified by its *guild_id*.
+    def guild_stage_instances(guild_id : UInt64 | Snowflake) : Array(UInt64)
+      @guild_stage_instances[guild_id.to_u64]
+    end
+
+    # Marks a Stage instance, identified by the *instance_id*, as belonging to a particular
+    # guild, identified by the *guild_id*.
+    def add_guild_stage_instance(guild_id : UInt64 | Snowflake, instance_id : UInt64 | Snowflake)
+      guild_id = guild_id.to_u64
+      instance_id = instance_id.to_u64
+      local_instances = @guild_stage_instances[guild_id] ||= [] of UInt64
+      local_instances << instance_id
+    end
+
+    # Marks a Stage instance as not belonging to a particular guild anymore.
+    def remove_guild_stage_instance(guild_id : UInt64 | Snowflake, instance_id : UInt64 | Snowflake)
+      guild_id = guild_id.to_u64
+      instance_id = instance_id.to_u64
+      @guild_stage_instances[guild_id]?.try { |local_instances| local_instances.delete(instance_id) }
     end
   end
 end

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -639,6 +639,8 @@ module Discord
         payload = StageInstance.from_json(data)
         cache payload
 
+        @cache.try &.add_guild_stage_instance(payload.guild_id, payload.id)
+
         call_event stage_instance_create, payload
       when "STAGE_INSTANCE_UPDATE"
         payload = StageInstance.from_json(data)
@@ -649,8 +651,7 @@ module Discord
         payload = StageInstance.from_json(data)
 
         @cache.try &.delete_stage_instance(payload.id)
-        guild_id = payload.guild_id.not_nil!
-        @cache.try &.remove_guild_stage_instance(guild_id, payload.id)
+        @cache.try &.remove_guild_stage_instance(payload.guild_id, payload.id)
 
         call_event stage_instance_delete, payload
       when "TYPING_START"

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -503,6 +503,11 @@ module Discord
           cache voice_state
         end
 
+        payload.stage_instances.each do |stage_instance|
+          cache stage_instance
+          @cache.try &.add_guild_stage_instance(guild.id, stage_instance.id)
+        end
+
         call_event guild_create, payload
       when "GUILD_UPDATE"
         payload = Guild.from_json(data)
@@ -630,6 +635,24 @@ module Discord
         end
 
         call_event presence_update, payload
+      when "STAGE_INSTANCE_CREATE"
+        payload = StageInstance.from_json(data)
+        cache payload
+
+        call_event stage_instance_create, payload
+      when "STAGE_INSTANCE_UPDATE"
+        payload = StageInstance.from_json(data)
+        cache payload
+
+        call_event stage_instance_update, payload
+      when "STAGE_INSTANCE_DELETE"
+        payload = StageInstance.from_json(data)
+
+        @cache.try &.delete_stage_instance(payload.id)
+        guild_id = payload.guild_id.not_nil!
+        @cache.try &.remove_guild_stage_instance(guild_id, payload.id)
+
+        call_event stage_instance_delete, payload
       when "TYPING_START"
         payload = Gateway::TypingStartPayload.from_json(data)
 
@@ -877,6 +900,21 @@ module Discord
     #
     # [API docs for this event](https://discord.com/developers/docs/topics/gateway#presence-update)
     event presence_update, Gateway::PresenceUpdatePayload
+
+    # Sent when a Stage instance is created.
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#stage-instance-create)
+    event stage_instance_create, StageInstance
+
+    # Sent when a Stage instance is updated.
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#stage-instance-update)
+    event stage_instance_update, StageInstance
+
+    # Sent when a Stage instance is deleted.
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#stage-instance-delete)
+    event stage_instance_delete, StageInstance
 
     # Called when somebody starts typing in a channel the bot has access to.
     #

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -64,13 +64,14 @@ module Discord
   end
 
   enum ChannelType : UInt8
-    GuildText     = 0
-    DM            = 1
-    GuildVoice    = 2
-    GroupDM       = 3
-    GuildCategory = 4
-    GuildNews     = 5
-    GuildStore    = 6
+    GuildText       =  0
+    DM              =  1
+    GuildVoice      =  2
+    GroupDM         =  3
+    GuildCategory   =  4
+    GuildNews       =  5
+    GuildStore      =  6
+    GuildStageVoice = 13
 
     def self.new(pull : JSON::PullParser)
       ChannelType.new(pull.read_int.to_u8)

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -117,6 +117,30 @@ module Discord
     end
   end
 
+  enum StagePrivacyLevel : UInt8
+    PUBLIC     = 1
+    GUILD_ONLY = 2
+
+    def self.new(pull : JSON::PullParser)
+      StagePrivacyLevel.new(pull.read_int.to_u8)
+    end
+
+    def to_json(json : JSON::Builder)
+      json.number(value)
+    end
+  end
+
+  struct StageInstance
+    include JSON::Serializable
+
+    getter id : Snowflake
+    getter guild_id : Snowflake
+    getter channel_id : Snowflake
+    getter topic : String
+    getter privacy_level : StagePrivacyLevel
+    getter discoverable_disabled : Bool
+  end
+
   struct PrivateChannel
     include JSON::Serializable
 

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -226,6 +226,7 @@ module Discord
       property default_message_notifications : UInt8
       property explicit_content_filter : UInt8
       property system_channel_id : Snowflake?
+      property stage_instances : Array(StageInstance)
 
       {% unless flag?(:correct_english) %}
         def emojis

--- a/src/discordcr/mappings/permissions.cr
+++ b/src/discordcr/mappings/permissions.cr
@@ -31,6 +31,7 @@ module Discord
     ManageRoles         = 1 << 28
     ManageWebhooks      = 1 << 29
     ManageEmojis        = 1 << 30
+    RequestToSpeak      = 1 << 32
 
     def self.new(pull : JSON::PullParser)
       Permissions.new(pull.read_int.to_u64)

--- a/src/discordcr/mappings/voice.cr
+++ b/src/discordcr/mappings/voice.cr
@@ -14,6 +14,9 @@ module Discord
     property self_deaf : Bool
     property self_mute : Bool
     property suppress : Bool
+
+    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+    property request_to_speak_timestamp : Time?
   end
 
   struct VoiceRegion

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -889,6 +889,34 @@ module Discord
       )
     end
 
+    # Updates the current user's, or passed user's voice state.
+    # For use with Stage Channels only.
+    # The user that is being updated must be inside of the stage channel.
+    # Requires "MUTE_MEMBERS" to (un)suppress other members, you can always suppress yourself.
+    # Requires "REQUEST_TO_SPEAK" to request to speak.
+    #
+    # [API docs for this method](todo)
+    def modify_voice_state(guild_id : UInt64 | Snowflake,
+                           channel_id : UInt64 | Snowflake,
+                           user_id : UInt64 | Snowflake | Nil = nil,
+                           suppress : Bool? = nil,
+                           request_to_speak_timestamp : Time? = nil)
+      json = encode_tuple(
+        channel_id: channel_id,
+        suppress: suppress,
+        request_to_speak_timestamp: request_to_speak_timestamp,
+      )
+
+      request(
+        :guilds_gid_voicestate,
+        guild_id,
+        "PATCH",
+        "/guilds/#{guild_id}/voice-states/#{user_id || "@me"}",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+    end
+
     # Modifies the position of channels within a guild. Requires the
     # "Manage Channels" permission.
     #

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -858,6 +858,79 @@ module Discord
       Channel.from_json(response.body)
     end
 
+    # Creates a new Stage instance associated to a Stage channel.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/stage-instance#create-stage-instance)
+    def create_stage_instance(channel_id : UInt64 | Snowflake, topic : String, privacy_level : StagePrivacyLevel = StagePrivacyLevel::GUILD_ONLY)
+      json = encode_tuple(
+        channel_id: channel_id,
+        topic: topic,
+        privacy_level: privacy_level
+      )
+
+      response = request(
+        :stage_instances_cid,
+        channel_id,
+        "POST",
+        "/stage-instances",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+
+      StageInstance.from_json(response.body)
+    end
+
+    # Gets the Stage instance associated with the passed Stage channel if it exists.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/stage-instance#get-stage-instance)
+    def get_stage_instance(channel_id : UInt64 | Snowflake)
+      response = request(
+        :stage_instances_cid,
+        channel_id,
+        "GET",
+        "/stage-instances/#{channel_id}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      StageInstance.from_json(response.body)
+    end
+
+    # Updates fields of an existing Stage instance.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/stage-instance#update-stage-instance)
+    def update_stage_instance(channel_id : UInt64 | Snowflake, topic : String? = nil, privacy_level : StagePrivacyLevel? = nil)
+      json = encode_tuple(
+        topic: topic,
+        privacy_level: privacy_level
+      )
+
+      response = request(
+        :stage_instances_cid,
+        channel_id,
+        "PATCH",
+        "/stage-instances/#{channel_id}",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+
+      StageInstance.from_json(response.body)
+    end
+
+    # Deletes the Stage instance associated with the passed Stage channel.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance)
+    def delete_stage_instance(channel_id : UInt64 | Snowflake)
+      request(
+        :stage_instances_cid,
+        channel_id,
+        "DELETE",
+        "/stage-instances/#{channel_id}",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
     # Gets the vanity URL of a guild. Requires the guild to be partnered.
     #
     # There are no API docs for this method.

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -968,7 +968,7 @@ module Discord
     # Requires "MUTE_MEMBERS" to (un)suppress other members, you can always suppress yourself.
     # Requires "REQUEST_TO_SPEAK" to request to speak.
     #
-    # [API docs for this method](todo)
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#update-current-user-voice-state)
     def modify_voice_state(guild_id : UInt64 | Snowflake,
                            channel_id : UInt64 | Snowflake,
                            user_id : UInt64 | Snowflake | Nil = nil,


### PR DESCRIPTION
Adds new stage channel properties and types.
and the new endpoint to manage self/user voice states.

PR to stay in Draft until Discord merges and finalizes their docs pr and permissions stuff.

TODO:
 - [x] Manage self voice state
 - [x] Manage other voice states
 - [x] Stage Instances
 
 Docs Link: https://github.com/discord/discord-api-docs/pull/2751