### PR TITLE
Upgrade to API v8 - REST and the rest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 
 deploy_key
+*.png

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: discordcr
-version: 0.4.0
+version: 0.5.0
 crystal: 1.0.0
 
 authors:

--- a/spec/rest_spec.cr
+++ b/spec/rest_spec.cr
@@ -6,5 +6,866 @@ describe Discord::REST do
       client = Discord::Client.new("foo", 0_u64)
       client.encode_tuple(foo: ["bar", 1, 2], baz: nil).should eq(%({"foo":["bar",1,2]}))
     end
+
+    it "emits values correctly" do
+      client = Discord::Client.new("foo", 0_u64)
+      client.encode_tuple(string: "foobar", int: 12345678, array: ["barfoo", "testfoo"], hash: {"bar" => 3.14, "foo" => "rab"}, enum_value: Discord::NSFWLevel::Explicit).should eq(%({"string":"foobar","int":12345678,"array":["barfoo","testfoo"],"hash":{"bar":3.14,"foo":"rab"},"enum_value":1}))
+    end
   end
+end
+
+#
+# Discord REST API Tests
+#
+# These tests require a valid Discord Bot Token, Guild ID, Channel ID, and User ID.
+# Bot is required to have all permissions in given Guild and Channel.
+# During tests chnages will be applied to given Guild and Channel so it is
+# advised to only run these tests on a "test" Guild and Channel.
+#
+# You might also want to provide an Application ID for the Application Command tests.
+#
+# NOTE: These tests can take a while to complete (around 1 minute and 30 seconds) due to rate limiting
+
+{% unless env("TOKEN") && env("GUILD") && env("CHANNEL") && env("USER") %}
+  {{ skip_file }}
+{% end %}
+
+TEST_GUILD   = {{ env("GUILD") }}.to_u64
+TEST_CHANNEL = {{ env("CHANNEL") }}.to_u64
+TEST_USER    = {{ env("USER") }}.to_u64
+
+CLIENT = Discord::Client.new "Bot " + {{ env("TOKEN") }}
+
+describe Discord::REST do
+  describe "#get_gateway" do
+    it "retrives Discord gateway URL" do
+      CLIENT.get_gateway.should be_a(Discord::REST::GatewayResponse)
+    end
+  end
+
+  describe "#get_gateway_bot" do
+    it "retrives Discord gateway bot URL and sharding information" do
+      CLIENT.get_gateway_bot.should be_a(Discord::REST::GatewayBotResponse)
+    end
+  end
+
+  describe "#get_oauth2_application" do
+    it "retrives OAuth2 Application for current bot" do
+      CLIENT.get_oauth2_application.should be_a(Discord::Application)
+    end
+  end
+
+  describe "#get_audit_log" do
+    it "retrives Audit Log" do
+      CLIENT.get_audit_log(TEST_GUILD, TEST_USER, limit: 5).should be_a(Discord::AuditLog)
+    end
+  end
+
+  describe "#get_channel" do
+    it "retrives Channel" do
+      CLIENT.get_channel(TEST_CHANNEL).should be_a(Discord::Channel)
+    end
+  end
+
+  describe "#modify_channel" do
+    it "modifies Channel" do
+      random_uuid = UUID.random.to_s
+      CLIENT.modify_channel(TEST_CHANNEL, topic: random_uuid, reason: "Discord::REST #modify_channel modifies Channel").topic.should eq(random_uuid)
+    end
+  end
+
+  mid = 0_u64
+  describe "#get_channel_messages" do
+    it "retrives messages form channel" do
+      (m = CLIENT.get_channel_messages(TEST_CHANNEL, limit: 10)).should be_a(Array(Discord::Message))
+      mid = m[0].id.value if m.size > 0
+    end
+  end
+
+  describe "#get_channel_message" do
+    it "retrives message from channel" do
+      fail("could not retrive any message id") if mid == 0
+      CLIENT.get_channel_message(TEST_CHANNEL, mid).should be_a(Discord::Message)
+    end
+  end
+
+  avatar = ""
+  describe "#get_user" do
+    it "retrives User" do
+      (user = CLIENT.get_user(TEST_USER)).should be_a(Discord::User)
+      avatar = user.avatar_url(Discord::CDN::ExtraImageFormat::PNG, 512)
+      HTTP::Client.get(avatar) do |response|
+        unless response.success?
+          fail("could not get the avatar of TEST_USER")
+        end
+        File.write "testUserAvatar.png", response.body_io
+      end
+    end
+  end
+
+  describe "#create_message" do
+    it "sends a normal message" do
+      CLIENT.create_message(TEST_CHANNEL, "Discord::REST #create_message sends a normal message\nRandom UUID: #{UUID.random}").should be_a(Discord::Message)
+    end
+
+    it "sends a simple embedded message" do
+      CLIENT.create_message(TEST_CHANNEL, embeds: [Discord::Embed.new("Embed Title", description: "Discord::REST #create_message sends a simple embedded message", colour: 0xFF00FF)]).should be_a(Discord::Message)
+    end
+
+    it "sends file" do
+      CLIENT.create_message(TEST_CHANNEL, content: "Discord::REST #create_message sends file", file: "testUserAvatar.png").should be_a(Discord::Message)
+    end
+
+    it "sends an embedded message with attachment" do
+      thumb = Discord::EmbedThumbnail.new("attachment://testUserAvatar.png")
+      author = Discord::EmbedAuthor.new("Embed Author", icon_url: "attachment://testUserAvatar.png")
+      footer = Discord::EmbedFooter.new("Embed Footer", icon_url: "attachment://testUserAvatar.png")
+      fields = [
+        Discord::EmbedField.new("Embed Field #1", "Value"),
+        Discord::EmbedField.new("Embed Field #2", "Eulav"),
+      ]
+      embed = Discord::Embed.new("Title", description: "Complex Embedded Message with Attachment", thumbnail: thumb, author: author, footer: footer, fields: fields, colour: 0x00FFFF)
+      CLIENT.create_message(TEST_CHANNEL, content: "Discord::REST #create_message sends an embedded message with attachment", file: "testUserAvatar.png", embeds: [embed]).should be_a(Discord::Message)
+    end
+  end
+
+  describe "#upload_file" do
+    it "sends file spoiler" do
+      (m = CLIENT.upload_file(TEST_CHANNEL, "Discord::REST #upload_file sends file spoiler", File.open("testUserAvatar.png"), "av.png", true)).should be_a(Discord::Message)
+      mid = m.id.value
+    end
+  end
+
+  describe "#create_reaction" do
+    it "creates message reaction" do
+      mid = send_test_message(CLIENT, TEST_CHANNEL) if mid == 0
+      CLIENT.create_reaction(TEST_CHANNEL, mid, "🆗")
+    end
+  end
+
+  describe "#delete_own_reaction" do
+    it "removes message reaction" do
+      mid = send_test_message(CLIENT, TEST_CHANNEL) if mid == 0
+      CLIENT.create_reaction(TEST_CHANNEL, mid, "❌")
+      CLIENT.delete_own_reaction(TEST_CHANNEL, mid, "❌")
+    end
+  end
+
+  describe "#delete_user_reaction" do
+    it "removes message reaction" do
+      mid = send_test_message(CLIENT, TEST_CHANNEL) if mid == 0
+      CLIENT.create_reaction(TEST_CHANNEL, mid, "❌")
+      CLIENT.delete_user_reaction(TEST_CHANNEL, mid, "❌", CLIENT.client_id)
+    end
+  end
+
+  describe "#get_reactions" do
+    it "retrives reactions information" do
+      mid = send_test_message(CLIENT, TEST_CHANNEL) if mid == 0
+      CLIENT.create_reaction(TEST_CHANNEL, mid, "🆗")
+      (r = CLIENT.get_reactions(TEST_CHANNEL, mid, "🆗")).should be_a(Array(Discord::User))
+      r.size.should eq(1)
+    end
+  end
+
+  describe "#delete_all_reactions" do
+    it "removes all message reactions" do
+      mid = send_test_message(CLIENT, TEST_CHANNEL) if mid == 0
+      CLIENT.create_reaction(TEST_CHANNEL, mid, "🆗")
+      CLIENT.delete_all_reactions(TEST_CHANNEL, mid)
+    end
+  end
+
+  describe "#delete_reaction" do
+    it "removes message reaction" do
+      mid = send_test_message(CLIENT, TEST_CHANNEL) if mid == 0
+      CLIENT.create_reaction(TEST_CHANNEL, mid, "🆗")
+      CLIENT.delete_reaction(TEST_CHANNEL, mid, "🆗")
+    end
+  end
+
+  bot_avatar = ""
+  describe "#get_current_user" do
+    it "retrives current User" do
+      (user = CLIENT.get_current_user).should be_a(Discord::User)
+      bot_avatar = user.avatar_url(Discord::CDN::ExtraImageFormat::PNG, 512)
+      HTTP::Client.get(bot_avatar) do |response|
+        unless response.success?
+          fail("could not get the avatar of the bot")
+        end
+        File.write "testBotAvatar.png", response.body_io
+      end
+    end
+  end
+
+  describe "#edit_message" do
+    it "modifies message contents" do
+      mid = send_test_message(CLIENT, TEST_CHANNEL) if mid == 0
+      CLIENT.edit_message(TEST_CHANNEL, mid, content: "Discord::REST #edit_message modifies message contents").should be_a(Discord::Message)
+    end
+
+    it "modifies message by adding a file" do
+      m = CLIENT.create_message(TEST_CHANNEL, content: "Discord::REST #edit_message modifies message by adding a file - Preparation stage")
+      CLIENT.edit_message(TEST_CHANNEL, m.id, content: "Discord::REST #edit_message modifies message by adding a file", file: "testBotAvatar.png").should be_a(Discord::Message)
+    end
+
+    it "modifies sent embedded message" do
+      embed = Discord::Embed.new("Embed Title - Preparation", description: "Discord::REST #edit_message modifies sent embedded message - Preparation stage", colour: 0xFF0000)
+      m = CLIENT.create_message(TEST_CHANNEL, embeds: [embed])
+      embed = Discord::Embed.new("Embed Title", description: "Discord::REST #edit_message modifies sent embedded message", colour: 0x00FF00)
+      CLIENT.edit_message(TEST_CHANNEL, m.id, embeds: [embed]).should be_a(Discord::Message)
+    end
+  end
+
+  describe "#delete_message" do
+    it "removes a message" do
+      m = CLIENT.create_message(TEST_CHANNEL, content: "Discord::REST #delete_message removes a message - Preparation stage")
+      CLIENT.delete_message(TEST_CHANNEL, m.id.value)
+    end
+  end
+
+  describe "#bulk_delete_messages" do
+    it "removes sevral messages" do
+      ids = [] of UInt64
+      5.times { |i| ids << CLIENT.create_message(TEST_CHANNEL, content: "Discord::REST #bulk_delete_messages removes sevral messages - Preparation stage ##{i + 1}").id.value }
+      CLIENT.bulk_delete_messages(TEST_CHANNEL, ids)
+    end
+  end
+
+  describe "#edit_channel_permissions" do
+    it "modifies channel permissions" do
+      CLIENT.edit_channel_permissions(TEST_CHANNEL, CLIENT.client_id, Discord::OverwriteType::Member, allow: Discord::Permissions::All, reason: "Discord::REST #edit_channel_permissions modifies channel permissions")
+    end
+  end
+
+  inv_code = ""
+  describe "#create_channel_invite" do
+    it "creates invite to a channel" do
+      (i = CLIENT.create_channel_invite(TEST_CHANNEL, max_age: 60_u64, max_uses: 1_u32, reason: "Discord::REST #create_channel_invite creates invite to a channel")).should be_a(Discord::Invite)
+      inv_code = i.code
+    end
+  end
+
+  describe "#get_channel_invites" do
+    it "retrives invites for channel" do
+      CLIENT.get_channel_invites(TEST_CHANNEL).should be_a(Array(Discord::InviteMetadata))
+    end
+  end
+
+  describe "#delete_channel_permission" do
+    it "removes channel permissions" do
+      CLIENT.delete_channel_permission(TEST_CHANNEL, CLIENT.client_id)
+    end
+  end
+
+  describe "#trigger_typing_indicator" do
+    it "triggers typing indicator" do
+      CLIENT.trigger_typing_indicator(TEST_CHANNEL)
+    end
+  end
+
+  describe "#pin_message" do
+    it "pins message" do
+      mid = send_test_message(CLIENT, TEST_CHANNEL) if mid == 0
+      CLIENT.pin_message(TEST_CHANNEL, mid, "Discord::REST #pin_message pins message")
+    end
+  end
+
+  describe "#get_pinned_messages" do
+    it "retrives a list of pinned messages" do
+      mid = send_test_message(CLIENT, TEST_CHANNEL) if mid == 0
+      CLIENT.pin_message(TEST_CHANNEL, mid)
+      CLIENT.get_pinned_messages(TEST_CHANNEL).should be_a(Array(Discord::Message))
+    end
+  end
+
+  describe "#unpin_message" do
+    it "unpins message" do
+      CLIENT.get_pinned_messages(TEST_CHANNEL).each do |m|
+        CLIENT.unpin_message(TEST_CHANNEL, m.id)
+      end
+    end
+  end
+
+  describe "#create_guild_emoji" do
+    it "created a guild custom emoji" do
+      base = Base64.encode(File.read("testBotAvatar.png")).gsub("\n", "")
+      CLIENT.create_guild_emoji(TEST_GUILD, "test_bot", "data:image/png;base64,#{base}", reason: "Discord::REST #create_guild_emoji created a guild custom emoji").should be_a(Discord::Emoji)
+    end
+  end
+
+  describe "#list_guild_emojis" do
+    it "retrives a list of custom guild emojis" do
+      CLIENT.list_guild_emojis(TEST_GUILD).should be_a(Array(Discord::Emoji))
+    end
+  end
+
+  describe "#get_guild_emoji" do
+    it "retrive a custom guild emoji" do
+      es = CLIENT.list_guild_emojis(TEST_GUILD)
+      fail("no guild emojis") if es.size == 0
+      CLIENT.get_guild_emoji(TEST_GUILD, es[0].id.not_nil!.value).should be_a(Discord::Emoji)
+    end
+  end
+
+  describe "#modify_guild_emoji" do
+    it "modifies a custom guild emoji" do
+      es = CLIENT.list_guild_emojis(TEST_GUILD)
+      fail("no guild emojis") if es.size == 0
+      CLIENT.modify_guild_emoji(TEST_GUILD, es[0].id.not_nil!, name: "bot_test", reason: "Discord::REST #modify_guild_emoji modifies a custom guild emoji").should be_a(Discord::Emoji)
+    end
+
+    it "modifies a custom guild emoji with roles" do
+      es = CLIENT.list_guild_emojis(TEST_GUILD)
+      fail("no guild emojis") if es.size == 0
+      CLIENT.modify_guild_emoji(TEST_GUILD, es[0].id.not_nil!, name: "t_bot", roles: nil, reason: "Discord::REST #modify_guild_emoji modifies a custom guild emoji with roles").should be_a(Discord::Emoji)
+    end
+  end
+
+  describe "#delete_guild_emoji" do
+    it "removes a custom guild emoji" do
+      es = CLIENT.list_guild_emojis(TEST_GUILD)
+      fail("no guild emojis") if es.size == 0
+      CLIENT.delete_guild_emoji(TEST_GUILD, es[0].id.not_nil!)
+    end
+  end
+
+  describe "#get_guild" do
+    it "retrives Guild" do
+      CLIENT.get_guild(TEST_GUILD, true).should be_a(Discord::Guild)
+    end
+  end
+
+  describe "#get_guild_preview" do
+    it "retrives Guild Preview" do
+      CLIENT.get_guild_preview(TEST_GUILD).should be_a(Discord::GuildPreview)
+    end
+  end
+
+  describe "#modify_guild" do
+    it "modifies guild" do
+      (g = CLIENT.modify_guild(TEST_GUILD, "Discord::REST #modify_guild modifies guild", preferred_locale: "en-GB", afk_channel_id: nil)).should be_a(Discord::Guild)
+      g.preferred_locale.should eq("en-GB")
+      g.afk_channel_id.should be_nil
+    end
+  end
+
+  describe "#get_guild_channels" do
+    it "retrive a list of channels" do
+      CLIENT.get_guild_channels(TEST_GUILD).should be_a(Array(Discord::Channel))
+    end
+  end
+
+  tcid = 0_u64
+  describe "#create_guild_channel" do
+    it "creates a guild channel" do
+      message = "Discord::REST #create_guild_channel creates a guild channel"
+      random_uuid = UUID.random.to_s
+      (c = CLIENT.create_guild_channel(TEST_GUILD, random_uuid, Discord::ChannelType::GuildText, topic: message, reason: message)).should be_a(Discord::Channel)
+      c.name.should eq(random_uuid)
+      c.topic.should eq(message)
+      tcid = c.id.value
+    end
+  end
+
+  describe "#modify_guild_channel_positions" do
+    it "moves guild channels" do
+      fail("no channel was created by tests") if tcid == 0
+      CLIENT.modify_guild_channel_positions(TEST_GUILD, [Discord::REST::ModifyChannelPositionPayload.new(tcid, position: 2)])
+    end
+  end
+
+  describe "#delete_channel" do
+    it "removes a guild channel" do
+      fail("no channel was created by tests") if tcid == 0
+      CLIENT.delete_channel(tcid)
+    end
+  end
+
+  describe "#get_guild_member" do
+    it "retrives Guild Member" do
+      CLIENT.get_guild_member(TEST_GUILD, TEST_USER).should be_a(Discord::GuildMember)
+    end
+  end
+
+  describe "#list_guild_members" do
+    it "retrives a list of Guild Members" do
+      CLIENT.list_guild_members(TEST_GUILD).should be_a(Array(Discord::GuildMember))
+    end
+  end
+
+  describe "#search_guild_members" do
+    it "searches for Guild Members" do
+      user = CLIENT.get_current_user
+      (m = CLIENT.search_guild_members(TEST_GUILD, user.username)).should be_a(Array(Discord::GuildMember))
+      m[0].user.not_nil!.id.should eq(user.id)
+    end
+  end
+
+  describe "#modify_current_user_nick" do
+    it "modifies bots nickname" do
+      CLIENT.modify_current_user_nick(TEST_GUILD, "TestBot##{Random::Secure.next_u.to_s[..5]}", "Discord::REST #modify_current_user_nick modifies bots nickname")
+    end
+  end
+
+  describe "#get_guild_bans" do
+    it "retrives Guild Bans" do
+      CLIENT.get_guild_bans(TEST_GUILD).should be_a(Array(Discord::GuildBan))
+    end
+  end
+
+  describe "#get_guild_roles" do
+    it "retrives guild Roles" do
+      CLIENT.get_guild_roles(TEST_GUILD).should be_a(Array(Discord::Role))
+    end
+  end
+
+  trid = 0_u64
+  describe "#create_guild_role" do
+    it "creates a guild role" do
+      name = UUID.random.to_s
+      (r = CLIENT.create_guild_role(TEST_GUILD, name: name, mentionable: false, reason: "Discord::REST #create_guild_role creates a guild role")).should be_a(Discord::Role)
+      r.name.should eq(name)
+      trid = r.id.value
+    end
+  end
+
+  describe "#modify_guild_role_positions" do
+    it "moves role" do
+      fail("no role was created by tests") if trid == 0
+      CLIENT.modify_guild_role_positions(TEST_GUILD, [Discord::REST::ModifyRolePositionPayload.new(trid, 2)]).should be_a(Array(Discord::Role))
+    end
+  end
+
+  describe "#modify_guild_role" do
+    it "modifies guild role" do
+      fail("no role was created by tests") if trid == 0
+      CLIENT.modify_guild_role(TEST_GUILD, trid, mentionable: true, reason: "Discord::REST #modify_guild_role modifies guild role").should be_a(Discord::Role)
+    end
+  end
+
+  describe "#add_guild_member_role" do
+    it "gives a role to a guild member" do
+      fail("no role was created by tests") if trid == 0
+      CLIENT.add_guild_member_role(TEST_GUILD, TEST_USER, trid, "Discord::REST #add_guild_member_role gives a role to a guild member")
+    end
+  end
+
+  describe "#remove_guild_member_role" do
+    it "takes away a role from a guild member" do
+      fail("no role was created by tests") if trid == 0
+      CLIENT.remove_guild_member_role(TEST_GUILD, TEST_USER, trid)
+    end
+  end
+
+  describe "#delete_guild_role" do
+    it "removes guil role" do
+      fail("no role was created by tests") if trid == 0
+      CLIENT.delete_guild_role(TEST_GUILD, trid)
+    end
+  end
+
+  describe "#get_guild_prune_count" do
+    it "retrives guild prune count" do
+      CLIENT.get_guild_prune_count(TEST_GUILD)
+    end
+  end
+
+  describe "#get_guild_voice_regions" do
+    it "retrives Voice Regions" do
+      CLIENT.get_guild_voice_regions(TEST_GUILD).should be_a(Array(Discord::VoiceRegion))
+    end
+  end
+
+  describe "#get_guild_invites" do
+    it "retrives guild invites" do
+      CLIENT.get_guild_invites(TEST_GUILD).should be_a(Array(Discord::InviteMetadata))
+    end
+  end
+
+  describe "#get_guild_integrations" do
+    it "retrives guild integrations" do
+      CLIENT.get_guild_integrations(TEST_GUILD).should be_a(Array(Discord::Integration))
+    end
+  end
+
+  describe "#get_guild_widget_settings" do
+    it "retrives guild widget settings" do
+      CLIENT.get_guild_widget_settings(TEST_GUILD).should be_a(Discord::GuildWidgetSettings)
+    end
+  end
+
+  describe "#modify_guild_widget" do
+    it "modifies guild widget settings" do
+      CLIENT.modify_guild_widget(TEST_GUILD, enabled: true).should be_a(Discord::GuildWidgetSettings)
+    end
+  end
+
+  describe "#get_guild_widget" do
+    it "retrives guild widget" do
+      CLIENT.get_guild_widget(TEST_GUILD).should be_a(Discord::GuildWidget)
+    end
+  end
+
+  tcode = ""
+  describe "#create_guild_templates" do
+    it "creates a guild template from a guild" do
+      name = UUID.random.to_s
+      (t = CLIENT.create_guild_templates(TEST_GUILD, name, "Discord::REST #create_guild_templates creates a guild template from a guild")).should be_a(Discord::GuildTemplate)
+      t.name.should eq(name)
+      tcode = t.code
+    end
+  end
+
+  describe "#get_guild_template" do
+    it "retrives Guild Template" do
+      fail("no guild template was created by tests") if tcode == ""
+      CLIENT.get_guild_template(tcode).should be_a(Discord::GuildTemplate)
+    end
+  end
+
+  describe "#get_guild_templates" do
+    it "retrives guild templates" do
+      CLIENT.get_guild_templates(TEST_GUILD).should be_a(Array(Discord::GuildTemplate))
+    end
+  end
+
+  describe "#sync_guild_templates" do
+    it "syncs guild template with the guild" do
+      fail("no guild template was created by tests") if tcode == ""
+      CLIENT.sync_guild_templates(TEST_GUILD, tcode).should be_a(Discord::GuildTemplate)
+    end
+  end
+
+  describe "#modify_guild_templates" do
+    it "modifies guild template" do
+      fail("no guild template was created by tests") if tcode == ""
+      CLIENT.modify_guild_templates(TEST_GUILD, tcode, description: "Discord::REST #modify_guild_templates modifies guild template").should be_a(Discord::GuildTemplate)
+    end
+  end
+
+  describe "#delete_guild_templates" do
+    it "removes guild template" do
+      fail("no guild template was created by tests") if tcode == ""
+      CLIENT.delete_guild_templates(TEST_GUILD, tcode)
+    end
+  end
+
+  describe "#get_invite" do
+    it "retrives invite" do
+      fail("no invite was created by tests") if inv_code == ""
+      CLIENT.get_invite(inv_code).should be_a(Discord::Invite)
+    end
+  end
+
+  describe "#delete_invite" do
+    it "deletes invite" do
+      fail("no invite was created by tests") if inv_code == ""
+      CLIENT.delete_invite(inv_code)
+    end
+  end
+
+  describe "#modify_current_user" do
+    it "modifies current user" do
+      CLIENT.modify_current_user.should be_a(Discord::User)
+    end
+  end
+
+  describe "#get_current_user_guilds" do
+    it "retrives current users guilds" do
+      CLIENT.get_current_user_guilds.should be_a(Array(Discord::PartialGuild))
+    end
+  end
+
+  describe "#create_dm" do
+    it "creates a direct messaging channel with the test user" do
+      CLIENT.create_dm(TEST_USER).should be_a(Discord::PrivateChannel)
+    end
+  end
+
+  describe "#get_user_connections" do
+    it "retrives user connections" do
+      CLIENT.get_user_connections.should be_a(Array(Discord::Connection))
+    end
+  end
+
+  describe "#list_voice_regions" do
+    it "retrives a list of voice regions" do
+      CLIENT.list_voice_regions.should be_a(Array(Discord::VoiceRegion))
+    end
+  end
+
+  twid = 0_u64
+  token = ""
+  describe "#create_webhook" do
+    it "created a webhook" do
+      name = UUID.random.to_s
+      (w = CLIENT.create_webhook(TEST_CHANNEL, name)).should be_a(Discord::Webhook)
+      w.name.should eq(name)
+      twid = w.id.value
+      token = w.token || ""
+    end
+  end
+
+  describe "#get_channel_webhooks" do
+    it "retrives webhooks for channel" do
+      CLIENT.get_channel_webhooks(TEST_CHANNEL).should be_a(Array(Discord::Webhook))
+    end
+  end
+
+  describe "#get_webhook" do
+    it "retrives webhook" do
+      fail("no webhook created by tests") if twid == 0
+      CLIENT.get_webhook(twid).should be_a(Discord::Webhook)
+    end
+
+    it "retrives webhook with token" do
+      fail("no webhook created by tests") if twid == 0
+      CLIENT.get_webhook(twid, token).should be_a(Discord::Webhook)
+    end
+  end
+
+  describe "#modify_webhook" do
+    it "modifies webhook" do
+      fail("no webhook created by tests") if twid == 0
+      name = UUID.random.to_s
+      (w = CLIENT.modify_webhook(twid, name: name)).should be_a(Discord::Webhook)
+      w.name.should eq(name)
+    end
+
+    it "modifies webhook with token" do
+      fail("no webhook created by tests") if twid == 0
+      name = UUID.random.to_s
+      (w = CLIENT.modify_webhook_with_token(twid, token, name: name)).should be_a(Discord::Webhook)
+      w.name.should eq(name)
+    end
+  end
+
+  twmid1 = twmid2 = twmid3 = twmid4 = 0_u64
+  describe "#execute_webhook" do
+    it "sends a normal message" do
+      fail("no webhook created by tests") if twid == 0
+      (m = CLIENT.execute_webhook(twid, token, "Discord::REST #execute_webhook sends a normal message\nRandom UUID: #{UUID.random}", wait: true)).should be_a(Discord::Message)
+      twmid1 = m.not_nil!.id.value
+    end
+
+    it "sends a simple embedded message" do
+      fail("no webhook created by tests") if twid == 0
+      (m = CLIENT.execute_webhook(twid, token, embeds: [Discord::Embed.new("Embed Title", description: "Discord::REST #execute_webhook sends a simple embedded message", colour: 0xFF00FF)], wait: true)).should be_a(Discord::Message)
+      twmid2 = m.not_nil!.id.value
+    end
+
+    it "sends file" do
+      fail("no webhook created by tests") if twid == 0
+      (m = CLIENT.execute_webhook(twid, token, content: "Discord::REST #execute_webhook sends file", file: "testUserAvatar.png", wait: true)).should be_a(Discord::Message)
+      twmid3 = m.not_nil!.id.value
+    end
+
+    it "sends an embedded message with attachment" do
+      fail("no webhook created by tests") if twid == 0
+      thumb = Discord::EmbedThumbnail.new("attachment://testUserAvatar.png")
+      author = Discord::EmbedAuthor.new("Embed Author", icon_url: "attachment://testUserAvatar.png")
+      footer = Discord::EmbedFooter.new("Embed Footer", icon_url: "attachment://testUserAvatar.png")
+      fields = [
+        Discord::EmbedField.new("Embed Field #1", "Value"),
+        Discord::EmbedField.new("Embed Field #2", "Eulav"),
+      ]
+      embed = Discord::Embed.new("Title", description: "Complex Embedded Message with Attachment", thumbnail: thumb, author: author, footer: footer, fields: fields, colour: 0x00FFFF)
+      (m = CLIENT.execute_webhook(twid, token, content: "Discord::REST #execute_webhook sends an embedded message with attachment", file: "testUserAvatar.png", embeds: [embed], wait: true)).should be_a(Discord::Message)
+      twmid4 = m.not_nil!.id.value
+    end
+  end
+
+  describe "#get_webhook_message" do
+    it "retrives webhook message" do
+      fail("no webhook created by tests") if twid == 0
+      CLIENT.get_webhook_message(twid, token, twmid1).should be_a(Discord::Message)
+      CLIENT.get_webhook_message(twid, token, twmid2).should be_a(Discord::Message)
+      CLIENT.get_webhook_message(twid, token, twmid3).should be_a(Discord::Message)
+      CLIENT.get_webhook_message(twid, token, twmid4).should be_a(Discord::Message)
+    end
+  end
+
+  describe "#edit_webhook_message" do
+    it "modifies webhook message contents" do
+      fail("no webhook created by tests") if twid == 0
+      CLIENT.edit_webhook_message(twid, token, twmid1, content: "Discord::REST #edit_webhook_message modifies message contents").should be_a(Discord::Message)
+    end
+
+    it "modifies webhook message by adding a file" do
+      fail("no webhook created by tests") if twid == 0
+      CLIENT.edit_webhook_message(twid, token, twmid1, content: "Discord::REST #edit_webhook_message modifies message by adding a file", file: "testBotAvatar.png").should be_a(Discord::Message)
+    end
+
+    it "modifies embedded webhook message" do
+      fail("no webhook created by tests") if twid == 0
+      embed = Discord::Embed.new("Embed Title", description: "Discord::REST #edit_webhook_message modifies sent embedded message", colour: 0x00FF00)
+      CLIENT.edit_webhook_message(twid, token, twmid2, embeds: [embed]).should be_a(Discord::Message)
+    end
+  end
+
+  describe "#delete_webhook_message" do
+    it "removes webhook message" do
+      fail("no webhook created by tests") if twid == 0
+      CLIENT.delete_webhook_message(twid, token, twmid3)
+    end
+  end
+
+  describe "#delete_webhook" do
+    it "removes webhook" do
+      fail("no webhook created by tests") if twid == 0
+      CLIENT.delete_webhook(twid)
+    end
+  end
+
+  {% if env("APPLICATION") %}
+  test_application = {{ env("APPLICATION") }}.to_u64
+
+  tgapid = 0_u64
+  tgapname = ""
+  describe "#create_global_application_command" do
+    it "creates a global application command" do
+      tgapname = UUID.random.to_s[..20]
+      description = "Discord::REST #create_global_application_command creates a global application command"
+      (a = CLIENT.create_global_application_command(test_application, tgapname, description)).should be_a(Discord::ApplicationCommand)
+      a.name.should eq(tgapname)
+    end
+
+    it "creates a global application command with options" do
+      name = UUID.random.to_s[..20]
+      description = "Discord::REST #create_global_application_command creates a global application command with options"
+      options = [
+        Discord::ApplicationCommandOption.new(UUID.random.to_s[..20], Discord::ApplicationCommandOptionType::String, "test 1"),
+        Discord::ApplicationCommandOption.new(UUID.random.to_s[..20], Discord::ApplicationCommandOptionType::Integer, "test 2"),
+      ]
+      (a = CLIENT.create_global_application_command(test_application, name, description, options)).should be_a(Discord::ApplicationCommand)
+      a.name.should eq(name)
+      a.options.not_nil!.size.should eq(2)
+      tgapid = a.id.value
+    end
+  end
+
+  describe "#get_global_application_commands" do
+    it "retrives global application commands" do
+      CLIENT.get_global_application_commands(test_application).should be_a(Array(Discord::ApplicationCommand))
+    end
+  end
+
+  describe "#get_global_application_command" do
+    it "retrives a global application command" do
+      fail("no application command was created by tests") if tgapid == 0
+      CLIENT.get_global_application_command(test_application, tgapid).should be_a(Discord::ApplicationCommand)
+    end
+  end
+
+  describe "#edit_global_application_command" do
+    it "modifies global application command" do
+      fail("no application command was created by tests") if tgapid == 0
+      CLIENT.edit_global_application_command(test_application, tgapid, options: [] of Discord::ApplicationCommandOption).should be_a(Discord::ApplicationCommand)
+    end
+  end
+
+  describe "#bulk_overwrite_global_application_commands" do
+    it "modifies multiple global application commands" do
+      fail("no application command was created by tests") if tgapname == ""
+      CLIENT.bulk_overwrite_global_application_commands(test_application, [Discord::PartialApplicationCommand.new(tgapname, "TEST 1")]).should be_a(Array(Discord::ApplicationCommand))
+    end
+  end
+
+  describe "#delete_global_application_command" do
+    it "removes global application commands" do
+      CLIENT.get_global_application_commands(test_application).each do |gap|
+        CLIENT.delete_global_application_command(test_application, gap.id)
+      end
+    end
+  end
+
+  tapid = 0_u64
+  tapname = ""
+  describe "#create_guild_application_command" do
+    it "creates a guild application command" do
+      tapname = UUID.random.to_s[..20]
+      description = "Discord::REST #create_guild_application_command creates a guild application command"
+      (a = CLIENT.create_guild_application_command(test_application, TEST_GUILD, tapname, description)).should be_a(Discord::ApplicationCommand)
+      a.name.should eq(tapname)
+    end
+
+    it "creates a guild application command with options" do
+      name = UUID.random.to_s[..20]
+      description = "Discord::REST #create_guild_application_command creates a guild application command with options"
+      options = [
+        Discord::ApplicationCommandOption.new(UUID.random.to_s[..20], Discord::ApplicationCommandOptionType::String, "test 1"),
+        Discord::ApplicationCommandOption.new(UUID.random.to_s[..20], Discord::ApplicationCommandOptionType::Integer, "test 2"),
+      ]
+      (a = CLIENT.create_guild_application_command(test_application, TEST_GUILD, name, description, options)).should be_a(Discord::ApplicationCommand)
+      a.name.should eq(name)
+      a.options.not_nil!.size.should eq(2)
+      tapid = a.id.value
+    end
+  end
+  
+  describe "#get_guild_application_commands" do
+    it "retrives guild application commands" do
+      CLIENT.get_guild_application_commands(test_application, TEST_GUILD).should be_a(Array(Discord::ApplicationCommand))
+    end
+  end
+
+  describe "#get_guild_application_command" do
+    it "retrives a guild application command" do
+      fail("no application command was created by tests") if tapid == 0
+      CLIENT.get_guild_application_command(test_application, TEST_GUILD, tapid).should be_a(Discord::ApplicationCommand)
+    end
+  end
+
+  describe "#edit_guild_application_command" do
+    it "modifies a guild application command" do
+      fail("no application command was created by tests") if tapid == 0
+      CLIENT.edit_guild_application_command(test_application, TEST_GUILD, tapid, options: [] of Discord::ApplicationCommandOption).should be_a(Discord::ApplicationCommand)
+    end
+  end
+
+  describe "#bulk_overwrite_guild_application_command" do
+    it "modifies multiple guild application commands" do
+      fail("no application command was created by tests") if tapname == 0
+      (a = CLIENT.bulk_overwrite_guild_application_command(test_application, TEST_GUILD, [Discord::PartialApplicationCommand.new(tapname, "TEST 1")])).should be_a(Array(Discord::ApplicationCommand))
+      a.size.should eq(1)
+      tapid = a[0].id.value
+    end
+  end
+
+  describe "#get_guild_application_command_permissions" do
+    it "retrives guild application command permissions" do
+      CLIENT.get_guild_application_command_permissions(test_application, TEST_GUILD).should be_a(Array(Discord::GuildApplicationCommandPermissions))
+    end
+  end
+
+  describe "#edit_application_command_permissions" do
+    it "modifies a guild application command permissions" do
+      fail("no application command was created by tests") if tapid == 0
+      CLIENT.edit_application_command_permissions(test_application, TEST_GUILD, tapid, [Discord::ApplicationCommandPermissions.user(TEST_USER, false)])
+    end
+  end
+
+  describe "#batch_edit_application_command_permissions" do
+    it "modifies multiple guild application command permissions" do
+      fail("no application command was created by tests") if tapid == 0
+      CLIENT.batch_edit_application_command_permissions(test_application, TEST_GUILD, {tapid => [Discord::ApplicationCommandPermissions.user(TEST_USER, true)]})
+    end
+  end
+
+  describe "#get_application_command_permissions" do
+    it "retrives a guild application command permission" do
+      fail("no application command was created by tests") if tapid == 0
+      CLIENT.get_application_command_permissions(test_application, TEST_GUILD, tapid).should be_a(Discord::GuildApplicationCommandPermissions)
+    end
+  end
+
+  describe "#delete_guild_application_command" do
+    it "removes guild application commands" do
+      CLIENT.get_guild_application_commands(test_application, TEST_GUILD).each do |ap|
+        CLIENT.delete_guild_application_command(test_application, TEST_GUILD, ap.id)
+      end
+    end
+  end
+  {% end %}
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,7 @@
 require "spec"
-require "../src/discordcr"
+require "uuid"
+require "../src/discordcr.cr"
+
+def send_test_message(client, channel_id) : UInt64
+  CLIENT.create_message(channel_id, content: "Test message").id.value
+end

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -685,15 +685,6 @@ module Discord
       when "INTERACTION_CREATE"
         payload = Interaction.from_json(data)
         call_event interaction_create, payload
-      when "STAGE_INSTANCE_CREATE"
-        payload = StageInstance.from_json(data)
-        call_event stage_instance_create, payload
-      when "STAGE_INSTANCE_UPDATE"
-        payload = StageInstance.from_json(data)
-        call_event stage_instance_update, payload
-      when "STAGE_INSTANCE_DELETE"
-        payload = StageInstance.from_json(data)
-        call_event stage_instance_delete, payload
       when "APPLICATION_COMMAND_PERMISSIONS_UPDATE"
         payload = GuildApplicationCommandPermissions.from_json(data)
         call_event application_command_permissions_update, payload
@@ -975,21 +966,6 @@ module Discord
     #
     # [API docs for this event](https://discord.com/developers/docs/topics/gateway#webhooks-update)
     event webhooks_update, Gateway::WebhooksUpdatePayload
-
-    # Sent when a Stage instance is created (i.e. the Stage is now "live"). Inner payload is a Stage instance
-    #
-    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#stage-instance-create)
-    event stage_instance_create, StageInstance
-
-    # Sent when a Stage instance has been updated. Inner payload is a Stage instance
-    #
-    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#stage-instance-update)
-    event stage_instance_update, StageInstance
-
-    # Sent when a Stage instance has been deleted (i.e. the Stage has been closed). Inner payload is a Stage instance
-    #
-    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#stage-instance-delete)
-    event stage_instance_delete, StageInstance
 
     # Sent when a Application Command Permission has been updated. Inner payload is a Guild Application Command Permissions
     #

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -1,8 +1,3 @@
-require "json"
-
-require "./rest"
-require "./cache"
-
 module Discord
   # Calculates the shard ID that would receive the gateway events from
   # a guild with the given `guild_id`, based on the total number of shards.
@@ -45,10 +40,15 @@ module Discord
     DEFAULT_PROPERTIES = Gateway::IdentifyProperties.new(
       os: "Crystal",
       browser: "discordcr",
-      device: "discordcr",
-      referrer: "",
-      referring_domain: ""
+      device: "discordcr"
     )
+
+    # Default gateway intents
+    DEFAULT_INTENTS = Gateway::Intents::Guilds |
+                      Gateway::Intents::GuildMessages |
+                      Gateway::Intents::GuildMessageReactions |
+                      Gateway::Intents::DirectMessages |
+                      Gateway::Intents::DirectMessageReactions
 
     # Available gateway compression modes that can be requested
     enum CompressMode
@@ -101,7 +101,8 @@ module Discord
                    @compress : CompressMode = CompressMode::Stream,
                    @zlib_buffer_size : Int32 = 10 * 1024 * 1024,
                    @properties : Gateway::IdentifyProperties = DEFAULT_PROPERTIES,
-                   @intents : Gateway::Intents? = nil)
+                   @intents : Gateway::Intents = DEFAULT_INTENTS,
+                   @initial_presence : Gateway::StatusUpdatePayload? = nil)
       @backoff = 1.0
 
       # Set some default value for the heartbeat interval. This should never
@@ -137,7 +138,6 @@ module Discord
           websocket.run
         rescue ex
           Log.error(exception: ex) { "[#{@client_name}] Received exception from WebSocket#run" }
-          Log.error { ex.inspect_with_backtrace }
         end
 
         @send_heartbeats = false
@@ -175,9 +175,9 @@ module Discord
       url = URI.parse(get_gateway.url)
 
       if @compress.stream?
-        path = "#{url.path}/?encoding=json&v=6&compress=zlib-stream"
+        path = "#{url.path}/?encoding=json&v=#{API_VERSION}&compress=zlib-stream"
       else
-        path = "#{url.path}/?encoding=json&v=6"
+        path = "#{url.path}/?encoding=json&v=#{API_VERSION}"
       end
 
       websocket = Discord::WebSocket.new(
@@ -248,11 +248,9 @@ module Discord
           end
         rescue ex : JSON::ParseException
           Log.error(exception: ex) { "[#{@client_name}] An exception occurred during message parsing! Please report this." }
-          Log.error { ex.inspect_with_backtrace }
           Log.error { "Previous exception raised with packet: #{packet}" }
         rescue ex
           Log.error(exception: ex) { "[#{@client_name}] A miscellaneous exception occurred during message handling." }
-          Log.error { ex.inspect_with_backtrace }
         end
 
         # Set the sequence to confirm that we have handled this packet, in case
@@ -306,7 +304,6 @@ module Discord
               @last_heartbeat_acked = false
             rescue ex
               Log.error(exception: ex) { "[#{@client_name}] Heartbeat failed!" }
-              Log.error { ex.inspect_with_backtrace }
             end
           end
 
@@ -321,7 +318,7 @@ module Discord
       end
 
       compress = @compress.large?
-      packet = Gateway::IdentifyPacket.new(@token, @properties, compress, @large_threshold, shard_tuple, @intents)
+      packet = Gateway::IdentifyPacket.new(@token, @properties, compress, @large_threshold, shard_tuple, @initial_presence, @intents)
       websocket.send(packet.to_json)
     end
 
@@ -359,13 +356,13 @@ module Discord
     end
 
     # Sends a status update to Discord. The *status* can be `"online"`,
-    # `"idle"`, `"dnd"`, or `"invisible"`. Setting the *game* to a `GamePlaying`
+    # `"idle"`, `"dnd"`, or `"invisible"`. Setting the *activities* to an `Array(Activity)`
     # object makes the bot appear as playing some game on Discord. *since* and
     # *afk* can be used in conjunction to signify to Discord that the status
     # change is due to inactivity on the bot's part – this fulfills no cosmetic
     # purpose.
-    def status_update(status : String? = nil, game : GamePlaying? = nil, afk : Bool = false, since : Int64? = nil)
-      packet = Gateway::StatusUpdatePacket.new(status, game, afk, since)
+    def status_update(status : String = "online", activities : Array(Gateway::Activity)? = nil, afk : Bool = false, since : Int64? = nil)
+      packet = Gateway::StatusUpdatePacket.new(status, activities, afk, since)
       websocket.send(packet.to_json)
     end
 
@@ -399,9 +396,13 @@ module Discord
       @on_{{name}}_handlers.try &.each do |handler|
         begin
           handler.call({{payload}})
+        rescue err : CodeException
+          Log.error(exception: err) { "[#{@client_name}] An exception occurred in a user-defined event handler!" }
+          if (he = err.human_errors) != ""
+            Log.error { "[#{@client_name}] Received error information from Discord#{he}" }
+          end
         rescue ex
           Log.error(exception: ex) { "[#{@client_name}] An exception occurred in a user-defined event handler!" }
-          Log.error { ex.inspect_with_backtrace }
         end
       end
     end
@@ -426,15 +427,6 @@ module Discord
 
         @cache.try &.cache_current_user(payload.user)
 
-        payload.private_channels.each do |channel|
-          cache Channel.new(channel)
-
-          if channel.type == 1 # DM channel, not group
-            recipient_id = channel.recipients[0].id
-            @cache.try &.cache_dm_channel(channel.id, recipient_id)
-          end
-        end
-
         Log.info { "[#{@client_name}] Received READY, v: #{payload.v}" }
         call_event ready, payload
       when "RESUMED"
@@ -446,6 +438,21 @@ module Discord
 
         payload = Gateway::ResumedPayload.from_json(data)
         call_event resumed, payload
+      when "RECONNECT"
+        Log.info { "[#{@client_name}] Received RECONNECT, commencing reconnect" }
+        handle_reconnect
+      when "APPLICATION_COMMAND_CREATE"
+        payload = Gateway::ApplicationCommandPayload.from_json(data)
+
+        call_event application_command_create, payload
+      when "APPLICATION_COMMAND_UPDATE"
+        payload = Gateway::ApplicationCommandPayload.from_json(data)
+
+        call_event application_command_update, payload
+      when "APPLICATION_COMMAND_DELETE"
+        payload = Gateway::ApplicationCommandPayload.from_json(data)
+
+        call_event application_command_delete, payload
       when "CHANNEL_CREATE"
         payload = Channel.from_json(data)
 
@@ -494,7 +501,7 @@ module Discord
         end
 
         payload.members.each do |member|
-          cache member.user
+          member.user.try { |user| cache user }
           @cache.try &.cache(member, guild.id)
         end
 
@@ -531,7 +538,7 @@ module Discord
       when "GUILD_MEMBER_ADD"
         payload = Gateway::GuildMemberAddPayload.from_json(data)
 
-        cache payload.user
+        payload.user.try { |user| cache user }
         member = GuildMember.new(payload)
         @cache.try &.cache(member, payload.guild_id)
 
@@ -626,7 +633,7 @@ module Discord
 
         if payload.user.full?
           member = GuildMember.new(payload)
-          @cache.try &.cache(member, payload.guild_id)
+          @cache.try &.cache(member, payload.guild_id.not_nil!) # GuildID is always present on PRESENCE_UPDATE event
         end
 
         call_event presence_update, payload
@@ -666,6 +673,30 @@ module Discord
       when "WEBHOOKS_UPDATE"
         payload = Gateway::WebhooksUpdatePayload.from_json(data)
         call_event webhooks_update, payload
+      when "INTEGRATION_CREATE"
+        payload = Gateway::IntegrationPayload.from_json(data)
+        call_event integration_create, payload
+      when "INTEGRATION_UPDATE"
+        payload = Gateway::IntegrationPayload.from_json(data)
+        call_event integration_update, payload
+      when "INTEGRATION_DELETE"
+        payload = Gateway::IntegrationDeletePayload.from_json(data)
+        call_event integration_delete, payload
+      when "INTERACTION_CREATE"
+        payload = Interaction.from_json(data)
+        call_event interaction_create, payload
+      when "STAGE_INSTANCE_CREATE"
+        payload = StageInstance.from_json(data)
+        call_event stage_instance_create, payload
+      when "STAGE_INSTANCE_UPDATE"
+        payload = StageInstance.from_json(data)
+        call_event stage_instance_update, payload
+      when "STAGE_INSTANCE_DELETE"
+        payload = StageInstance.from_json(data)
+        call_event stage_instance_delete, payload
+      when "APPLICATION_COMMAND_PERMISSIONS_UPDATE"
+        payload = GuildApplicationCommandPermissions.from_json(data)
+        call_event application_command_permissions_update, payload
       else
         Log.warn { "[#{@client_name}] Unsupported dispatch: #{type} #{data}" }
       end
@@ -719,6 +750,24 @@ module Discord
     #
     # [API docs for this event](https://discord.com/developers/docs/topics/gateway#resumed)
     event resumed, Gateway::ResumedPayload
+
+    # Sent when a new Slash Command is created, relevant to the current user.
+    # The inner payload is an ApplicationCommand object, with an optional extra guild_id key.
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#application-command-create)
+    event application_command_create, Gateway::ApplicationCommandPayload
+
+    # Sent when a Slash Command relevant to the current user is updated.
+    # The inner payload is an ApplicationCommand object, with an optional extra guild_id key.
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#application-command-update)
+    event application_command_update, Gateway::ApplicationCommandPayload
+
+    # Sent when a Slash Command relevant to the current user is deleted.
+    # The inner payload is an ApplicationCommand object, with an optional extra guild_id key.
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#application-command-delete)
+    event application_command_delete, Gateway::ApplicationCommandPayload
 
     # Called when a channel has been created on a server the bot has access to,
     # or when somebody has started a DM channel with the bot.
@@ -825,14 +874,34 @@ module Discord
     # [API docs for this event](https://discord.com/developers/docs/topics/gateway#guild-role-delete)
     event guild_role_delete, Gateway::GuildRoleDeletePayload
 
+    # Sent when an integration is created. The inner payload is a integration object with an additional guild_id key
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#integration-create)
+    event integration_create, Gateway::IntegrationPayload
+
+    # Sent when an integration is updated. The inner payload is a integration object with an additional guild_id key
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#integration-update)
+    event integration_update, Gateway::IntegrationPayload
+
+    # Sent when an integration is deleted.
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#integration-delete)
+    event integration_delete, Gateway::IntegrationDeletePayload
+
+    # Sent when a user in a guild uses a Slash Command. Inner payload is an Interaction.
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#interaction-create)
+    event interaction_create, Interaction
+
     # Called when an invite is created on a guild.
     #
-    # [API docs for this event](https://discordapp.com/developers/docs/topics/gateway#invite-create)
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#invite-create)
     event invite_create, Gateway::InviteCreatePayload
 
     # Called when an invite is deleted.
     #
-    # [API docs for this event](https://discordapp.com/developers/docs/topics/gateway#invite-delete)
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#invite-delete)
     event invite_delete, Gateway::InviteDeletePayload
 
     # Called when a message is sent to a channel the bot has access to. This
@@ -840,18 +909,6 @@ module Discord
     #
     # [API docs for this event](https://discord.com/developers/docs/topics/gateway#message-create)
     event message_create, Message
-
-    # Called when a reaction is added to a message.
-    event message_reaction_add, Gateway::MessageReactionPayload
-
-    # Called when a reaction is removed from a message.
-    event message_reaction_remove, Gateway::MessageReactionPayload
-
-    # Called when all reactions are removed at once from a message.
-    event message_reaction_remove_all, Gateway::MessageReactionRemoveAllPayload
-
-    # Called when all reactions of a single emoji are removed at once from a message.
-    event message_reaction_remove_emoji, Gateway::MessageReactionRemoveEmojiPayload
 
     # Called when a message is updated. Most commonly this is done for edited
     # messages, but the event is also sent when embed information for an
@@ -870,6 +927,18 @@ module Discord
     #
     # [API docs for this event](https://discord.com/developers/docs/topics/gateway#message-delete-bulk)
     event message_delete_bulk, Gateway::MessageDeleteBulkPayload
+
+    # Called when a reaction is added to a message.
+    event message_reaction_add, Gateway::MessageReactionPayload
+
+    # Called when a reaction is removed from a message.
+    event message_reaction_remove, Gateway::MessageReactionPayload
+
+    # Called when all reactions are removed at once from a message.
+    event message_reaction_remove_all, Gateway::MessageReactionRemoveAllPayload
+
+    # Called when all reactions of a single emoji are removed at once from a message.
+    event message_reaction_remove_emoji, Gateway::MessageReactionRemoveEmojiPayload
 
     # Called when a user updates their status (online/idle/offline), the game
     # they are playing, or their streaming status. Also called when a user's
@@ -906,6 +975,26 @@ module Discord
     #
     # [API docs for this event](https://discord.com/developers/docs/topics/gateway#webhooks-update)
     event webhooks_update, Gateway::WebhooksUpdatePayload
+
+    # Sent when a Stage instance is created (i.e. the Stage is now "live"). Inner payload is a Stage instance
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#stage-instance-create)
+    event stage_instance_create, StageInstance
+
+    # Sent when a Stage instance has been updated. Inner payload is a Stage instance
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#stage-instance-update)
+    event stage_instance_update, StageInstance
+
+    # Sent when a Stage instance has been deleted (i.e. the Stage has been closed). Inner payload is a Stage instance
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#stage-instance-delete)
+    event stage_instance_delete, StageInstance
+
+    # Sent when a Application Command Permission has been updated. Inner payload is a Guild Application Command Permissions
+    #
+    # Not documented, thanks Discord
+    event application_command_permissions_update, GuildApplicationCommandPermissions
   end
 
   module Gateway

--- a/src/discordcr/dca.cr
+++ b/src/discordcr/dca.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Discord
   # Parser for the DCA file format, a simple wrapper around Opus made
   # specifically for Discord bots.

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -1,30 +1,20 @@
-require "http/client"
-require "http/formdata"
-require "openssl/ssl/context"
-require "time/format"
-
-require "./mappings/*"
-require "./version"
-require "./errors"
-
 module Discord
   module REST
     SSL_CONTEXT = OpenSSL::SSL::Context::Client.new
-    USER_AGENT  = "DiscordBot (https://github.com/discordcr/discordcr, #{Discord::VERSION})"
-    API_BASE    = "https://discord.com/api/v6"
+    USER_AGENT  = "DiscordBot (https://github.com/shardlab/discordcr, #{Discord::VERSION})"
+    API_BASE    = "https://discord.com/api/v#{API_VERSION}"
 
     Log = Discord::Log.for("rest")
 
     alias RateLimitKey = {route_key: Symbol, major_parameter: UInt64?}
 
     # Like `#request`, but does not do error checking beyond 429.
-    def raw_request(route_key : Symbol, major_parameter : Snowflake | UInt64 | Nil, method : String, path : String, headers : HTTP::Headers, body : String?)
+    def raw_request(route_key : Symbol, major_parameter : Snowflake | UInt64 | Nil, method : String, path : String, headers : HTTP::Headers, body : String | IO::Memory | Nil)
       mutexes = (@mutexes ||= Hash(RateLimitKey, Mutex).new)
       global_mutex = (@global_mutex ||= Mutex.new)
 
       headers["Authorization"] = @token
       headers["User-Agent"] = USER_AGENT
-      headers["X-RateLimit-Precision"] = "millisecond"
 
       request_done = false
       rate_limit_key = {route_key: route_key, major_parameter: major_parameter.try(&.to_u64)}
@@ -38,7 +28,9 @@ module Discord
         global_mutex.synchronize { }
 
         Log.info { "[HTTP OUT] #{method} #{path} (#{body.try &.size || 0} bytes)" }
-        Log.debug { "[HTTP OUT] BODY: #{body}" }
+        Log.debug { "[HTTP OUT] BODY: #{body}" } if body.is_a?(String)
+
+        body.rewind if body.is_a?(IO::Memory)
 
         response = HTTP::Client.exec(method: method, url: API_BASE + path, headers: headers, body: body, tls: SSL_CONTEXT)
 
@@ -79,7 +71,7 @@ module Discord
     # won't block events from being processed.) It also performs other kinds
     # of error checking, so if a request fails (with a status code that is not
     # 429) you will be notified of that.
-    def request(route_key : Symbol, major_parameter : Snowflake | UInt64 | Nil, method : String, path : String, headers : HTTP::Headers, body : String?)
+    def request(route_key : Symbol, major_parameter : Snowflake | UInt64 | Nil, method : String, path : String, headers : HTTP::Headers, body : String | IO::Memory | Nil)
       response = raw_request(route_key, major_parameter, method, path, headers, body)
 
       unless response.success?
@@ -102,11 +94,23 @@ module Discord
         builder.object do
           tuple.each do |key, value|
             next if value.nil?
-            builder.field(key) { value.to_json(builder) }
+            builder.field(key) { (value.is_a?(Enum) ? value.value : value).to_json(builder) }
           end
         end
       end
     end
+
+    # :nodoc:
+    def header_with_reason(content_type : String?, reason : String?) : HTTP::Headers
+      header = HTTP::Headers.new
+      header["Content-Type"] = content_type if content_type
+      header["X-Audit-Log-Reason"] = reason if reason
+      header
+    end
+
+    #
+    # Topics -> Gateway
+    #
 
     # Gets the gateway URL to connect to.
     #
@@ -140,6 +144,10 @@ module Discord
       GatewayBotResponse.from_json(response.body)
     end
 
+    #
+    # Topics -> OAuth2
+    #
+
     # Gets the OAuth2 application tied to a client.
     #
     # [API docs for this method](https://discord.com/developers/docs/topics/oauth2#get-current-application-information)
@@ -153,8 +161,37 @@ module Discord
         nil
       )
 
-      OAuth2Application.from_json(response.body)
+      Application.from_json(response.body)
     end
+
+    #
+    # Resources -> Audit Log
+    #
+
+    # Returns an audit log object for the guild.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log)
+    def get_audit_log(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake | Nil = nil, action_type : UInt32 | AuditLogEvent | Nil = nil, before : UInt64 | Snowflake | Nil = nil, limit : UInt32? = nil)
+      query = user_id.nil? ? "" : "user_id=#{user_id}"
+      query += "&action_type=#{action_type}" if action_type
+      query += "&before=#{before}" if before
+      query += "&limit=#{limit}" if limit
+      query = "?#{query[0] == '&' ? query[1..] : query}" if query != ""
+      response = request(
+        :audit_log_gid,
+        guild_id,
+        "GET",
+        "/guilds/#{guild_id}/audit-logs#{query}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      AuditLog.from_json(response.body)
+    end
+
+    #
+    # Resources -> Channel
+    #
 
     # Gets a channel by ID.
     #
@@ -172,21 +209,18 @@ module Discord
       Channel.from_json(response.body)
     end
 
-    # Modifies a channel with new properties. Requires the "Manage Channel"
-    # permission.
+    # Modifies a DM channel with new properties.
+    # icon argument should contain a base64 encoded icon.
+    # icon_file argument should contain a path to an icon file.
+    # icon argument takes priority over icon_file.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#modify-channel)
-    def modify_channel(channel_id : UInt64 | Snowflake, name : String? = nil, position : UInt32? = nil,
-                       topic : String? = nil, bitrate : UInt32? = nil, user_limit : UInt32? = nil,
-                       nsfw : Bool? = nil, rate_limit_per_user : Int32? = nil)
+    def modify_dm_channel(channel_id : UInt64 | Snowflake, name : String? = nil, icon : String? = nil, icon_file : String? = nil)
+      icon = Base64.encode(File.read(icon_file)).gsub("\n", "") if icon.nil? && !icon_file.nil?
+
       json = encode_tuple(
         name: name,
-        position: position,
-        topic: topic,
-        bitrate: bitrate,
-        user_limit: user_limit,
-        nsfw: nsfw,
-        rate_limit_per_user: rate_limit_per_user
+        icon: icon,
       )
 
       response = request(
@@ -198,8 +232,44 @@ module Discord
         json
       )
 
+      PrivateChannel.from_json(response.body)
+    end
+
+    # Modifies a channel with new properties. Requires the "Manage Channel"
+    # permission.
+    #
+    # NOTE: To see valid fields, see `VALID_MODIFY_CHANNEL_ARGS` constant (beneath this method in code)
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#modify-channel)
+    def modify_channel(channel_id : UInt64 | Snowflake, reason : String? = nil, **args : **T) forall T
+      json = TypeCheck.args_check(args, VALID_MODIFY_CHANNEL_ARGS)
+
+      response = request(
+        :channels_cid,
+        channel_id,
+        "PATCH",
+        "/channels/#{channel_id}",
+        header_with_reason("application/json", reason),
+        json.to_json
+      )
+
       Channel.from_json(response.body)
     end
+
+    VALID_MODIFY_CHANNEL_ARGS = {
+      :name                  => TypeCheck(String),
+      :type                  => TypeCheck(UInt8 | ChannelType),
+      :position              => TypeCheck(UInt32?),
+      :topic                 => TypeCheck(String?),
+      :nsfw                  => TypeCheck(Bool?),
+      :rate_limit_per_user   => TypeCheck(UInt32?),
+      :bitrate               => TypeCheck(UInt32?),
+      :user_limit            => TypeCheck(UInt32?),
+      :permission_overwrites => TypeCheck(Array(Overwrite)?),
+      :parent_id             => TypeCheck(UInt64 | Snowflake | Nil),
+      :rtc_region            => TypeCheck(String?),
+      :video_quality_mode    => TypeCheck(UInt8 | VideoQualityMode | Nil),
+    }
 
     # Deletes a channel by ID. Requires the "Manage Channel" permission.
     #
@@ -220,16 +290,16 @@ module Discord
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#get-channel-messages)
     def get_channel_messages(channel_id : UInt64 | Snowflake, limit : Int32 = 50, before : UInt64 | Snowflake | Nil = nil, after : UInt64 | Snowflake | Nil = nil, around : UInt64 | Snowflake | Nil = nil)
-      path = "/channels/#{channel_id}/messages?limit=#{limit}"
-      path += "&before=#{before}" if before
-      path += "&after=#{after}" if after
-      path += "&around=#{around}" if around
+      query = "limit=#{limit}"
+      query += "&before=#{before}" if before
+      query += "&after=#{after}" if after
+      query += "&around=#{around}" if around
 
       response = request(
         :channels_cid_messages,
         channel_id,
         "GET",
-        path,
+        "/channels/#{channel_id}/messages?#{query}",
         HTTP::Headers.new,
         nil
       )
@@ -300,27 +370,78 @@ module Discord
     #   ],
     # )
     #
-    # client.create_message(channel_id, "The content of the message. This will display separately above the embed. This string can be empty.", embed)
+    # client.create_message(channel_id, "The content of the message. This will display separately above the embed. This string can be empty.", [embed])
     # ```
     #
     # For more details on the format of the `embed` object, look at the
     # [relevant documentation](https://discord.com/developers/docs/resources/channel#embed-object).
-    def create_message(channel_id : UInt64 | Snowflake, content : String, embed : Embed? = nil, tts : Bool = false,
+    def create_message(channel_id : UInt64 | Snowflake, content : String? = nil, embeds : Array(Embed)? = nil, file : String | IO | Nil = nil,
+                       filename : String? = nil, tts : Bool = false, allowed_mentions : AllowedMentions? = nil,
+                       message_reference : MessageReference? = nil, components : Array(Component)? = nil,
                        nonce : Int64 | String? = nil)
-      json = encode_tuple(
+      body = encode_tuple(
         content: content,
-        embed: embed,
         tts: tts,
-        nonce: nonce
+        embeds: embeds,
+        allowed_mentions: allowed_mentions,
+        message_reference: message_reference,
+        components: components,
+        nonce: nonce,
       )
+
+      content_type = "application/json"
+      body, content_type = send_file(body, file, filename) if file
 
       response = request(
         :channels_cid_messages,
         channel_id,
         "POST",
         "/channels/#{channel_id}/messages",
-        HTTP::Headers{"Content-Type" => "application/json"},
-        json
+        HTTP::Headers{"Content-Type" => content_type},
+        body
+      )
+
+      Message.from_json(response.body)
+    end
+
+    # :nodoc:
+    private def send_file(old_body : String, file : String | IO | Nil, filename : String?) : {IO::Memory, String}
+      file = File.open(file) if file.is_a?(String)
+      filename = (file.is_a?(File) ? File.basename(file.path) : "") unless filename
+      builder = HTTP::FormData::Builder.new((io = IO::Memory.new))
+      builder.field("payload_json", old_body, HTTP::Headers{"Content-Type" => "application/json"})
+      builder.file("file", file, HTTP::FormData::FileMetadata.new(filename: filename))
+      builder.finish
+      {io, builder.content_type}
+    end
+
+    # Uploads a file to a channel. Requires the "Send Messages" and "Attach
+    # Files" permissions.
+    #
+    # If the specified `file` is a `File` object and no filename is specified,
+    # the file's filename will be used instead. If it is an `IO` without
+    # filename information, Discord will generate a placeholder filename.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#create-message)
+    # (same as `#create_message` -- this method only )
+    def upload_file(channel_id : UInt64 | Snowflake, content : String?, file : IO, filename : String? = nil, spoiler : Bool = false)
+      filename = (file.is_a?(File) ? File.basename(file.path) : "") unless filename
+      filename = "SPOILER_" + filename if spoiler && !filename.starts_with?("SPOILER_")
+
+      create_message(channel_id, content, file: file, filename: filename)
+    end
+
+    # Crosspost a message in a News Channel to following channels.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#create-message)
+    def corsspost_message(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake)
+      response = request(
+        :channels_cid_messages_mid_crosspost,
+        channel_id,
+        "POST",
+        "/channels/#{channel_id}/messages/#{message_id}/crosspost",
+        HTTP::Headers.new,
+        nil
       )
 
       Message.from_json(response.body)
@@ -380,12 +501,14 @@ module Discord
     # Returns all users that have reacted with a specific emoji.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#get-reactions)
-    def get_reactions(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake, emoji : String)
+    def get_reactions(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake, emoji : String, limit : UInt32 = 25, after : UInt64 | Snowflake | Nil = nil)
+      query = "limit=#{limit}"
+      query += "&after=#{after}" if after
       response = request(
         :channels_cid_messages_mid_reactions_emoji_me,
         channel_id,
         "GET",
-        "/channels/#{channel_id}/messages/#{message_id}/reactions/#{URI.encode(emoji)}",
+        "/channels/#{channel_id}/messages/#{message_id}/reactions/#{URI.encode(emoji)}?#{query}",
         HTTP::Headers.new,
         nil
       )
@@ -423,60 +546,31 @@ module Discord
       )
     end
 
-    # Uploads a file to a channel. Requires the "Send Messages" and "Attach
-    # Files" permissions.
-    #
-    # If the specified `file` is a `File` object and no filename is specified,
-    # the file's filename will be used instead. If it is an `IO` without
-    # filename information, Discord will generate a placeholder filename.
-    #
-    # [API docs for this method](https://discord.com/developers/docs/resources/channel#create-message)
-    # (same as `#create_message` -- this method implements form data bodies
-    # while `#create_message` implements JSON bodies)
-    def upload_file(channel_id : UInt64 | Snowflake, content : String?, file : IO, filename : String? = nil, spoiler : Bool = false)
-      io = IO::Memory.new
-
-      unless filename
-        if file.is_a? File
-          filename = File.basename(file.path)
-        else
-          filename = ""
-        end
-      end
-
-      if spoiler && !filename.starts_with?("SPOILER_")
-        filename = "SPOILER_" + filename
-      end
-
-      builder = HTTP::FormData::Builder.new(io)
-      builder.field("content", content) if content
-      builder.file("file", file, HTTP::FormData::FileMetadata.new(filename: filename))
-      builder.finish
-
-      response = request(
-        :channels_cid_messages,
-        channel_id,
-        "POST",
-        "/channels/#{channel_id}/messages",
-        HTTP::Headers{"Content-Type" => builder.content_type},
-        io.to_s
-      )
-
-      Message.from_json(response.body)
-    end
-
     # Edits an existing message on the channel. This only works for messages
     # sent by the bot itself - you can't edit others' messages.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#edit-message)
-    def edit_message(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake, content : String, embed : Embed? = nil)
+    def edit_message(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake, content : String? = nil, embeds : Array(Embed)? = nil,
+                     file : String | IO | Nil = nil, filename : String? = nil, flags : UInt8 | MessageFlags | Nil = nil,
+                     allowed_mentions : AllowedMentions? = nil, components : Array(Component)? = nil)
+      body = encode_tuple(
+        content: content,
+        embeds: embeds,
+        flags: flags,
+        allowed_mentions: allowed_mentions,
+        components: components,
+      )
+
+      content_type = "application/json"
+      body, content_type = send_file(body, file, filename) if file
+
       response = request(
         :channels_cid_messages_mid,
         channel_id,
         "PATCH",
         "/channels/#{channel_id}/messages/#{message_id}",
-        HTTP::Headers{"Content-Type" => "application/json"},
-        {content: content, embed: embed}.to_json
+        HTTP::Headers{"Content-Type" => content_type},
+        body
       )
 
       Message.from_json(response.body)
@@ -519,7 +613,7 @@ module Discord
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#edit-channel-permissions)
     def edit_channel_permissions(channel_id : UInt64 | Snowflake, overwrite_id : UInt64 | Snowflake,
-                                 type : String, allow : Permissions, deny : Permissions)
+                                 type : OverwriteType, allow : Permissions? = nil, deny : Permissions? = nil, reason : String? = nil)
       json = encode_tuple(
         allow: allow,
         deny: deny,
@@ -531,7 +625,7 @@ module Discord
         channel_id,
         "PUT",
         "/channels/#{channel_id}/permissions/#{overwrite_id}",
-        HTTP::Headers{"Content-Type" => "application/json"},
+        header_with_reason("application/json", reason),
         json
       )
     end
@@ -557,12 +651,18 @@ module Discord
     # permission.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#create-channel-invite)
-    def create_channel_invite(channel_id : UInt64 | Snowflake, max_age : UInt32 = 0_u32,
-                              max_uses : UInt32 = 0_u32, temporary : Bool = false)
+    def create_channel_invite(channel_id : UInt64 | Snowflake, max_age : UInt32 = 86400_u32,
+                              max_uses : UInt32 = 0_u32, temporary : Bool = false, unique : Bool = false,
+                              target_type : UInt8 | InviteTargetType | Nil = nil, target_user_id : UInt64 | Snowflake | Nil = nil,
+                              target_application_id : UInt64 | Snowflake | Nil = nil, reason : String? = nil)
       json = encode_tuple(
         max_age: max_age,
         max_uses: max_uses,
-        temporary: temporary
+        temporary: temporary,
+        unique: unique,
+        target_type: target_type,
+        target_user_id: target_user_id,
+        target_application_id: target_application_id,
       )
 
       response = request(
@@ -570,7 +670,7 @@ module Discord
         channel_id,
         "POST",
         "/channels/#{channel_id}/invites",
-        HTTP::Headers{"Content-Type" => "application/json"},
+        header_with_reason("application/json", reason),
         json
       )
 
@@ -590,6 +690,22 @@ module Discord
         HTTP::Headers.new,
         nil
       )
+    end
+
+    # Follow a News Channel to send messages to a target webhook channel.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#follow-news-channel)
+    def follow_news_channel(channel_id : UIn64 | Snowflake, webhook_channel_id : UInt64 | Snowflake)
+      response = request(
+        :channels_cid_followers,
+        channel_id,
+        "POST",
+        "/channels/#{channel_id}/followers",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        {webhook_channel_id: webhook_channel_id}.to_json
+      )
+
+      FollowedChannel.from_json(response.body)
     end
 
     # Causes the bot to appear as typing on the channel. This generally lasts
@@ -627,14 +743,22 @@ module Discord
     # Pins a new message to this channel. Requires the "Manage Messages"
     # permission.
     #
-    # [API docs for this method](https://discord.com/developers/docs/resources/channel#add-pinned-channel-message)
-    def add_pinned_channel_message(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake)
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#pin-message)
+    def add_pinned_channel_message(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake, reason : String? = nil)
+      pin_message(channel_id, message_id, reason)
+    end
+
+    # Pins a new message to this channel. Requires the "Manage Messages"
+    # permission.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#pin-message)
+    def pin_message(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake, reason : String? = nil)
       response = request(
         :channels_cid_pins_mid,
         channel_id,
         "PUT",
         "/channels/#{channel_id}/pins/#{message_id}",
-        HTTP::Headers.new,
+        header_with_reason(nil, reason),
         nil
       )
     end
@@ -642,8 +766,16 @@ module Discord
     # Unpins a message from this channel. Requires the "Manage Messages"
     # permission.
     #
-    # [API docs for this method](https://discord.com/developers/docs/resources/channel#delete-pinned-channel-message)
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#unpin-message)
     def delete_pinned_channel_message(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake)
+      unpin_message(channel_id, message_id)
+    end
+
+    # Unpins a message from this channel. Requires the "Manage Messages"
+    # permission.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#unpin-message)
+    def unpin_message(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake)
       response = request(
         :channels_cid_pins_mid,
         channel_id,
@@ -654,74 +786,37 @@ module Discord
       )
     end
 
-    # Gets a guild by ID.
+    # Adds a recipient to a Group DM using their access token.
     #
-    # [API docs for this method](https://discord.com/developers/docs/resources/guild#get-guild)
-    def get_guild(guild_id : UInt64 | Snowflake)
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#group-dm-add-recipient)
+    def group_dm_add_recipiant(channel_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake, access_token : String? = nil, nick : String? = nil)
       response = request(
-        :guilds_gid,
-        guild_id,
-        "GET",
-        "/guilds/#{guild_id}",
-        HTTP::Headers.new,
-        nil
+        :channels_cid_recipients_uid,
+        channel_id,
+        "PUT",
+        "/channels/#{channel_id}/recipients/#{user_id}",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        {access_token: access_token, nick: nick}.to_json
       )
-
-      Guild.from_json(response.body)
     end
 
-    # Modifies an existing guild with new properties. Requires the "Manage
-    # Server" permission.
-    # NOTE: To remove a guild's icon, you can send an empty string for the `icon` argument.
+    # Removes a recipient from a Group DM.
     #
-    # [API docs for this method](https://discord.com/developers/docs/resources/guild#modify-guild)
-    def modify_guild(guild_id : UInt64 | Snowflake, name : String? = nil, region : String? = nil,
-                     verification_level : UInt8? = nil, afk_channel_id : UInt64 | Snowflake | Nil = nil,
-                     afk_timeout : Int32? = nil, icon : String? = nil, owner_id : UInt64 | Snowflake | Nil = nil,
-                     splash : String? = nil, reason : String? = nil)
-      json = encode_tuple(
-        name: name,
-        region: region,
-        verification_level: verification_level,
-        afk_channel_id: afk_channel_id,
-        afk_timeout: afk_timeout,
-        icon: icon,
-        owner_id: owner_id,
-        splash: splash
-      )
-
-      headers = HTTP::Headers{
-        "Content-Type" => "application/json",
-      }
-      headers["X-Audit-Log-Reason"] = reason if reason
-
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#group-dm-remove-recipient)
+    def group_dm_remove_recipiant(channel_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake)
       response = request(
-        :guilds_gid,
-        guild_id,
-        "PATCH",
-        "/guilds/#{guild_id}",
-        headers,
-        json
-      )
-
-      Guild.from_json(response.body)
-    end
-
-    # Deletes a guild. Requires the bot to be the server owner.
-    #
-    # [API docs for this method](https://discord.com/developers/docs/resources/guild#delete-guild)
-    def delete_guild(guild_id : UInt64 | Snowflake)
-      response = request(
-        :guilds_gid,
-        guild_id,
+        :channels_cid_recipients_uid,
+        channel_id,
         "DELETE",
-        "/guilds/#{guild_id}",
+        "/channels/#{channel_id}/recipients/#{user_id}",
         HTTP::Headers.new,
         nil
       )
-
-      Guild.from_json(response.body)
     end
+
+    #
+    # Resources -> Emoji
+    #
 
     # Gets a list of emoji on the guild.
     #
@@ -755,29 +850,14 @@ module Discord
       Emoji.from_json(response.body)
     end
 
-    # Modifies a guild emoji. Requires the "Manage Emojis" permission.
-    #
-    # [API docs for this method](https://discord.com/developers/docs/resources/emoji#modify-guild-emoji)
-    def modify_guild_emoji(guild_id : UInt64 | Snowflake, emoji_id : UInt64 | Snowflake, name : String)
-      response = request(
-        :guilds_gid_emojis_eid,
-        guild_id,
-        "PATCH",
-        "/guilds/#{guild_id}/emojis/#{emoji_id}",
-        HTTP::Headers{"Content-Type" => "application/json"},
-        {name: name}.to_json
-      )
-
-      Emoji.from_json(response.body)
-    end
-
     # Creates a guild emoji. Requires the "Manage Emojis" permission.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/emoji#create-guild-emoji)
-    def create_guild_emoji(guild_id : UInt64 | Snowflake, name : String, image : String)
+    def create_guild_emoji(guild_id : UInt64 | Snowflake, name : String, image : String, roles : Array(UInt64 | Snowflake)? = nil, reason : String? = nil)
       json = encode_tuple(
         name: name,
         image: image,
+        roles: roles,
       )
 
       response = request(
@@ -785,12 +865,37 @@ module Discord
         guild_id,
         "POST",
         "/guilds/#{guild_id}/emojis",
-        HTTP::Headers{"Content-Type" => "application/json"},
+        header_with_reason("application/json", reason),
         json
       )
 
       Emoji.from_json(response.body)
     end
+
+    # Modifies a guild emoji. Requires the "Manage Emojis" permission.
+    #
+    # NOTE: To see valid fields, see `VALID_MODIFY_GUILD_EMOJI_ARGS` constant (beneath this method in code)
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/emoji#modify-guild-emoji)
+    def modify_guild_emoji(guild_id : UInt64 | Snowflake, emoji_id : UInt64 | Snowflake, reason : String? = nil, **args : **T) forall T
+      json = TypeCheck.args_check(args, VALID_MODIFY_GUILD_EMOJI_ARGS)
+
+      response = request(
+        :guilds_gid_emojis_eid,
+        guild_id,
+        "PATCH",
+        "/guilds/#{guild_id}/emojis/#{emoji_id}",
+        header_with_reason("application/json", reason),
+        json.to_json
+      )
+
+      Emoji.from_json(response.body)
+    end
+
+    VALID_MODIFY_GUILD_EMOJI_ARGS = {
+      :name  => TypeCheck(String),
+      :roles => TypeCheck(Array(UInt64 | Snowflake)?),
+    }
 
     # Deletes a guild emoji. Requires the "Manage Emojis" permission.
     #
@@ -804,6 +909,103 @@ module Discord
         HTTP::Headers.new,
         nil
       )
+    end
+
+    #
+    # Resources -> Guild
+    #
+
+    # Gets a guild by ID.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#get-guild)
+    def get_guild(guild_id : UInt64 | Snowflake, with_counts : Bool = false)
+      response = request(
+        :guilds_gid,
+        guild_id,
+        "GET",
+        "/guilds/#{guild_id}?with_counts=#{with_counts}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Guild.from_json(response.body)
+    end
+
+    # Gets a guild preview by ID.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#get-guild-preview)
+    def get_guild_preview(guild_id : UInt64 | Snowflake)
+      response = request(
+        :guilds_gid_preview,
+        guild_id,
+        "GET",
+        "/guilds/#{guild_id}/preview",
+        HTTP::Headers.new,
+        nil
+      )
+
+      GuildPreview.from_json(response.body)
+    end
+
+    # Modifies an existing guild with new properties. Requires the "Manage
+    # Server" permission.
+    # NOTE: To remove a guild's icon, you can send an empty string or nil for the `icon` argument.
+    # NOTE: To see valid fields, see `VALID_MODIFY_GUILD_ARGS` constant (beneath this method in code)
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#modify-guild)
+    def modify_guild(guild_id : UInt64 | Snowflake, reason : String? = nil, **args : **T) forall T
+      json = TypeCheck.args_check(args, VALID_MODIFY_GUILD_ARGS)
+
+      response = request(
+        :guilds_gid,
+        guild_id,
+        "PATCH",
+        "/guilds/#{guild_id}",
+        header_with_reason("application/json", reason),
+        json.to_json
+      )
+
+      Guild.from_json(response.body)
+    end
+
+    # This Hash contains the valid arguments for `#modify_guild` method.
+    # Each pair describes a valid field present in [Discord's documentation](https://discord.com/developers/docs/resources/guild#modify-guild-json-params)
+    VALID_MODIFY_GUILD_ARGS = {
+      :name                          => TypeCheck(String),
+      :region                        => TypeCheck(String?),
+      :verification_level            => TypeCheck(UInt8 | VerificationLevel | Nil),
+      :default_message_notifications => TypeCheck(UInt8 | MessageNotificationLevel | Nil),
+      :explicit_content_filter       => TypeCheck(UInt8 | ExplicitContentFilter | Nil),
+      :afk_channel_id                => TypeCheck(UInt64 | Snowflake | Nil),
+      :afk_timeout                   => TypeCheck(Int32),
+      :icon                          => TypeCheck(String?),
+      :owner_id                      => TypeCheck(UInt64 | Snowflake),
+      :splash                        => TypeCheck(String?),
+      :discovery_splash              => TypeCheck(String?),
+      :banner                        => TypeCheck(String?),
+      :system_channel_id             => TypeCheck(UInt64 | Snowflake | Nil),
+      :system_channel_flags          => TypeCheck(UInt8 | SystemChannelFlags),
+      :rules_channel_id              => TypeCheck(UInt64 | Snowflake | Nil),
+      :public_updates_channel_id     => TypeCheck(UInt64 | Snowflake | Nil),
+      :preferred_locale              => TypeCheck(String?),
+      :features                      => TypeCheck(Array(String)),
+      :description                   => TypeCheck(String?),
+    }
+
+    # Deletes a guild. Requires the bot to be the server owner.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#delete-guild)
+    def delete_guild(guild_id : UInt64 | Snowflake)
+      response = request(
+        :guilds_gid,
+        guild_id,
+        "DELETE",
+        "/guilds/#{guild_id}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Guild.from_json(response.body)
     end
 
     # Gets a list of channels in a guild.
@@ -826,9 +1028,10 @@ module Discord
     # permission.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#create-guild-channel)
-    def create_guild_channel(guild_id : UInt64 | Snowflake, name : String, type : ChannelType, topic : String?,
-                             bitrate : UInt32?, user_limit : UInt32?, rate_limit_per_user : Int32?,
-                             position : UInt32?, parent_id : UInt64? | Snowflake?, nsfw : Bool?, reason : String? = nil)
+    def create_guild_channel(guild_id : UInt64 | Snowflake, name : String, type : UInt8 | ChannelType | Nil = nil, topic : String? = nil,
+                             bitrate : UInt32? = nil, user_limit : UInt32? = nil, rate_limit_per_user : Int32? = nil,
+                             position : UInt32? = nil, permission_overwrites : Array(Overwrite)? = nil,
+                             parent_id : UInt64 | Snowflake | Nil = nil, nsfw : Bool? = nil, reason : String? = nil)
       json = encode_tuple(
         name: name,
         type: type,
@@ -837,70 +1040,34 @@ module Discord
         user_limit: user_limit,
         rate_limit_per_user: rate_limit_per_user,
         position: position,
+        permission_overwrites: permission_overwrites,
         parent_id: parent_id,
         nsfw: nsfw
       )
-
-      headers = HTTP::Headers{
-        "Content-Type" => "application/json",
-      }
-      headers["X-Audit-Log-Reason"] = reason if reason
 
       response = request(
         :guilds_gid_channels,
         guild_id,
         "POST",
         "/guilds/#{guild_id}/channels",
-        headers,
+        header_with_reason("application/json", reason),
         json
       )
 
       Channel.from_json(response.body)
     end
 
-    # Gets the vanity URL of a guild. Requires the guild to be partnered.
-    #
-    # There are no API docs for this method.
-    def get_guild_vanity_url(guild_id : UInt64 | Snowflake)
-      response = request(
-        :guilds_gid_vanityurl,
-        guild_id,
-        "GET",
-        "/guilds/#{guild_id}/vanity-url",
-        HTTP::Headers.new,
-        nil
-      )
-
-      GuildVanityURLResponse.from_json(response.body).code
-    end
-
-    # Sets the vanity URL on this guild. Requires the guild to be
-    # partnered.
-    #
-    # There are no API docs for this method.
-    def modify_guild_vanity_url(guild_id : UInt64 | Snowflake, code : String)
-      request(
-        :guilds_gid_vanityurl,
-        guild_id,
-        "PATCH",
-        "/guilds/#{guild_id}/vanity-url",
-        HTTP::Headers{"Content-Type" => "application/json"},
-        {code: code}.to_json
-      )
-    end
-
     # Modifies the position of channels within a guild. Requires the
     # "Manage Channels" permission.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions)
-    def modify_guild_channel_positions(guild_id : UInt64 | Snowflake,
-                                       positions : Array(ModifyChannelPositionPayload))
+    def modify_guild_channel_positions(guild_id : UInt64 | Snowflake, positions : Array(ModifyChannelPositionPayload), reason : String? = nil)
       request(
         :guilds_gid_channels,
         guild_id,
         "PATCH",
         "/guilds/#{guild_id}/channels",
-        HTTP::Headers{"Content-Type" => "application/json"},
+        header_with_reason("application/json", reason),
         positions.to_json
       )
     end
@@ -926,14 +1093,15 @@ module Discord
     # to specify what ID to start at.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#list-guild-members)
-    def list_guild_members(guild_id : UInt64 | Snowflake, limit : Int32 = 1000, after : UInt64 | Snowflake = 0_u64)
-      path = "/guilds/#{guild_id}/members?limit=#{limit}&after=#{after}"
+    def list_guild_members(guild_id : UInt64 | Snowflake, limit : Int32 = 1000, after : UInt64 | Snowflake | Nil = nil)
+      query = "limit=#{limit}"
+      query += "&after=#{after}" if after
 
       response = request(
         :guilds_gid_members,
         guild_id,
         "GET",
-        path,
+        "/guilds/#{guild_id}/members?#{query}",
         HTTP::Headers.new,
         nil
       )
@@ -943,16 +1111,31 @@ module Discord
 
     # Returns a `Paginator` over the given guilds members.
     #
-    # Will yield members starting at `start_id` until  `limit` number of members
+    # Will yield members starting at `start_id` until `limit` number of members
     # guilds are observed, or the user has no further guilds. Setting `limit`
     # to `nil` will have the paginator continue to make requests until all members
     # are fetched.
-    def page_guild_members(guild_id : UInt64 | Snowflake, start_id : UInt64 | Snowflake = 0_u64,
-                           limit : Int32? = 1000, page_size : Int32 = 1000)
+    def page_guild_members(guild_id : UInt64 | Snowflake, start_id : UInt64 | Snowflake = 0_u64, limit : Int32? = 1000, page_size : Int32 = 1000)
       Paginator(GuildMember).new(limit, Paginator::Direction::Down) do |last_page|
         next_id = last_page.try &.last.user.id || start_id
         list_guild_members(guild_id, page_size, next_id)
       end
+    end
+
+    # Returns a list of guild member objects whose username or nickname starts with a provided string.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#search-guild-members)
+    def search_guild_members(guild_id : UInt64 | Snowflake, query : String, limit : Int32 = 1)
+      response = request(
+        :guilds_gid_members_search,
+        guild_id,
+        "GET",
+        "/guilds/#{guild_id}/members/search?query=#{URI.encode(query)}&limit=#{limit}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Array(GuildMember).from_json(response.body)
     end
 
     # Adds a user to the guild, provided you have a valid OAuth2 access token
@@ -962,16 +1145,14 @@ module Discord
     #   to create instant invites.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#add-guild-member)
-    def add_guild_member(guild_id : UInt64, user_id : UInt64,
-                         access_token : String, nick : String? = nil,
-                         roles : Array(UInt64)? = nil, mute : Bool? = nil,
-                         deaf : Bool? = nil)
+    def add_guild_member(guild_id : UInt64, user_id : UInt64, access_token : String, nick : String? = nil,
+                         roles : Array(UInt64 | Snowflake)? = nil, mute : Bool? = nil, deaf : Bool? = nil)
       json = encode_tuple(
         access_token: access_token,
         nick: nick,
         roles: roles,
         mute: mute,
-        deaf: deaf
+        deaf: deaf,
       )
 
       response = request(
@@ -1000,78 +1181,61 @@ module Discord
     #  - and the "Move Members" permission as well as the "Connect" permission
     #    to the new channel when changing voice channel ID.
     #
-    # NOTE: To remove a member's nickname, you can send an empty string for the `nick` argument.
+    # NOTE: To remove a member's nickname, you can send an empty string or nil for the `nick` argument.
+    # NOTE: To see valid fields, see `VALID_MODIFY_GUILD_MEMBER_ARGS` constant (beneath this method in code)
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#modify-guild-member)
-    def modify_guild_member(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake, nick : String? = nil,
-                            roles : Array(UInt64 | Snowflake)? = nil, mute : Bool? = nil, deaf : Bool? = nil,
-                            channel_id : UInt64 | Snowflake | Nil = nil, reason : String? = nil)
-      json = encode_tuple(
-        nick: nick,
-        roles: roles,
-        mute: mute,
-        deaf: deaf,
-        channel_id: channel_id
-      )
+    def modify_guild_member(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake, reason : String? = nil, **args : **T) forall T
+      json = TypeCheck.args_check(args, VALID_MODIFY_GUILD_MEMBER_ARGS)
 
-      headers = HTTP::Headers{
-        "Content-Type" => "application/json",
-      }
-      headers["X-Audit-Log-Reason"] = reason if reason
-
-      request(
+      response = request(
         :guilds_gid_members_uid,
         guild_id,
         "PATCH",
         "/guilds/#{guild_id}/members/#{user_id}",
-        headers,
-        json
+        header_with_reason("application/json", reason),
+        json.to_json
       )
+
+      GuildMember.from_json(response.body)
     end
+
+    # This Hash contains the valid arguments for `#modify_guild_member` method.
+    # Each pair describes a valid field present in [Discord's documentation](https://discord.com/developers/docs/resources/guild#modify-guild-member-json-params)
+    VALID_MODIFY_GUILD_MEMBER_ARGS = {
+      :nick       => TypeCheck(String?),
+      :roles      => TypeCheck(Array(UInt64 | Snowflake)?),
+      :mute       => TypeCheck(Bool?),
+      :deaf       => TypeCheck(Bool?),
+      :channel_id => TypeCheck(UInt64 | Snowflake | Nil),
+    }
 
     # Modifies the nickname of the current user in a guild.
     #
-    # NOTE: To remove a nickname, you can send an empty string for the `nick` argument.
+    # NOTE: To remove a nickname, you can send an empty string or nil for the `nick` argument.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#modify-current-user-nick)
-    def modify_current_user_nick(guild_id : UInt64, nick : String)
+    def modify_current_user_nick(guild_id : UInt64 | Snowflake, nick : String?, reason : String? = nil)
       request(
         :guilds_gid_members_me,
         guild_id,
         "PATCH",
         "/guilds/#{guild_id}/members/@me/nick",
-        HTTP::Headers{"Content-Type" => "application/json"},
+        header_with_reason("application/json", reason), # HTTP::Headers{"Content-Type" => "application/json"},
         {nick: nick}.to_json
-      )
-    end
-
-    # Kicks a member from the server. Requires the "Kick Members" permission.
-    #
-    # [API docs for this method](https://discord.com/developers/docs/resources/guild#remove-guild-member)
-    def remove_guild_member(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake, reason : String? = nil)
-      headers = HTTP::Headers.new
-      headers["X-Audit-Log-Reason"] = reason if reason
-
-      request(
-        :guilds_gid_members_uid,
-        guild_id,
-        "DELETE",
-        "/guilds/#{guild_id}/members/#{user_id}",
-        headers,
-        nil
       )
     end
 
     # Adds a role to a member. Requires the "Manage Roles" permission.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#add-guild-member-role)
-    def add_guild_member_role(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake, role_id : UInt64 | Snowflake)
+    def add_guild_member_role(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake, role_id : UInt64 | Snowflake, reason : String? = nil)
       request(
         :guilds_gid_members_uid_roles_rid,
         guild_id,
         "PUT",
         "/guilds/#{guild_id}/members/#{user_id}/roles/#{role_id}",
-        HTTP::Headers.new,
+        header_with_reason(nil, reason),
         nil
       )
     end
@@ -1079,13 +1243,27 @@ module Discord
     # Removes a role from a member. Requires the "Manage Roles" permission.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#remove-guild-member-role)
-    def remove_guild_member_role(guild_id : UInt64, user_id : UInt64, role_id : UInt64)
+    def remove_guild_member_role(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake, role_id : UInt64 | Snowflake)
       request(
         :guilds_gid_members_uid_roles_rid,
         guild_id,
         "DELETE",
         "/guilds/#{guild_id}/members/#{user_id}/roles/#{role_id}",
         HTTP::Headers.new,
+        nil
+      )
+    end
+
+    # Kicks a member from the server. Requires the "Kick Members" permission.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#remove-guild-member)
+    def remove_guild_member(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake, reason : String? = nil)
+      request(
+        :guilds_gid_members_uid,
+        guild_id,
+        "DELETE",
+        "/guilds/#{guild_id}/members/#{user_id}",
+        header_with_reason(nil, reason),
         nil
       )
     end
@@ -1111,16 +1289,13 @@ module Discord
     # permission.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#get-guild-ban)
-    def get_guild_ban(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake, reason : String? = nil)
-      headers = HTTP::Headers.new
-      headers["X-Audit-Log-Reason"] = reason if reason
-
+    def get_guild_ban(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake)
       response = request(
         :guilds_gid_bans_uid,
         guild_id,
         "GET",
         "/guilds/#{guild_id}/bans/#{user_id}",
-        headers,
+        HTTP::Headers.new,
         nil
       )
 
@@ -1130,8 +1305,7 @@ module Discord
     # Bans a member from the guild. Requires the "Ban Members" permission.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#create-guild-ban)
-    def create_guild_ban(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake,
-                         delete_message_days : Int32? = nil, reason : String? = nil)
+    def create_guild_ban(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake, delete_message_days : UInt32? = nil, reason : String? = nil)
       json = encode_tuple(
         delete_message_days: delete_message_days,
         reason: reason,
@@ -1151,15 +1325,12 @@ module Discord
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#remove-guild-ban)
     def remove_guild_ban(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake, reason : String? = nil)
-      headers = HTTP::Headers.new
-      headers["X-Audit-Log-Reason"] = reason if reason
-
       request(
         :guilds_gid_bans_uid,
         guild_id,
         "DELETE",
         "/guilds/#{guild_id}/bans/#{user_id}",
-        headers,
+        header_with_reason(nil, reason),
         nil
       )
     end
@@ -1184,59 +1355,22 @@ module Discord
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#create-guild-role)
     def create_guild_role(guild_id : UInt64 | Snowflake, name : String? = nil,
-                          permissions : Permissions? = nil, colour : UInt32 = 0_u32,
+                          permissions : Permissions? = nil, colour : UInt32? = nil,
                           hoist : Bool = false, mentionable : Bool = false, reason : String? = nil)
       json = encode_tuple(
         name: name,
         permissions: permissions,
         color: colour,
         hoist: hoist,
-        mentionable: mentionable
+        mentionable: mentionable,
       )
-
-      headers = HTTP::Headers{
-        "Content-Type" => "application/json",
-      }
-      headers["X-Audit-Log-Reason"] = reason if reason
 
       response = request(
         :get_guild_roles,
         guild_id,
         "POST",
         "/guilds/#{guild_id}/roles",
-        headers,
-        json
-      )
-
-      Role.from_json(response.body)
-    end
-
-    # Changes a role's properties. Requires the "Manage Roles" permission as
-    # well as the role to be lower than the bot's highest role.
-    #
-    # [API docs for this method](https://discord.com/developers/docs/resources/guild#modify-guild-role)
-    def modify_guild_role(guild_id : UInt64 | Snowflake, role_id : UInt64 | Snowflake, name : String? = nil,
-                          permissions : Permissions? = nil, colour : UInt32? = nil,
-                          position : Int32? = nil, hoist : Bool? = nil, reason : String? = nil)
-      json = encode_tuple(
-        name: name,
-        permissions: permissions,
-        color: colour,
-        position: position,
-        hoist: hoist
-      )
-
-      headers = HTTP::Headers{
-        "Content-Type" => "application/json",
-      }
-      headers["X-Audit-Log-Reason"] = reason if reason
-
-      response = request(
-        :guilds_gid_roles_rid,
-        guild_id,
-        "PATCH",
-        "/guilds/#{guild_id}/roles/#{role_id}",
-        headers,
+        header_with_reason("application/json", reason),
         json
       )
 
@@ -1247,8 +1381,7 @@ module Discord
     # and you cannot raise roles above the bot's highest role.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#modify-guild-role-positions)
-    def modify_guild_role_positions(guild_id : UInt64 | Snowflake,
-                                    positions : Array(ModifyRolePositionPayload))
+    def modify_guild_role_positions(guild_id : UInt64 | Snowflake, positions : Array(ModifyRolePositionPayload))
       response = request(
         :guilds_gid_roles,
         guild_id,
@@ -1261,20 +1394,47 @@ module Discord
       Array(Role).from_json(response.body)
     end
 
+    # Changes a role's properties. Requires the "Manage Roles" permission as
+    # well as the role to be lower than the bot's highest role.
+    #
+    # NOTE: To see valid fields, see `VALID_MODIFY_GUILD_ROLE_ARGS` constant (beneath this method in code)
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#modify-guild-role)
+    def modify_guild_role(guild_id : UInt64 | Snowflake, role_id : UInt64 | Snowflake, reason : String? = nil, **args : **T) forall T
+      json = TypeCheck.args_check(args, VALID_MODIFY_GUILD_ROLE_ARGS)
+      json["color"] = json.delete("colour").not_nil! if json.has_key? "colour"
+
+      response = request(
+        :guilds_gid_roles_rid,
+        guild_id,
+        "PATCH",
+        "/guilds/#{guild_id}/roles/#{role_id}",
+        header_with_reason("application/json", reason),
+        json.to_json
+      )
+
+      Role.from_json(response.body)
+    end
+
+    VALID_MODIFY_GUILD_ROLE_ARGS = {
+      :name        => TypeCheck(String?),
+      :permissions => TypeCheck(Permissions?),
+      :colour      => TypeCheck(UInt32?),
+      :hoist       => TypeCheck(Bool?),
+      :mentionable => TypeCheck(Bool?),
+    }
+
     # Deletes a role. Requires the "Manage Roles" permission as well as the role
     # to be lower than the bot's highest role.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#delete-guild-role)
-    def delete_guild_role(guild_id : UInt64 | Snowflake, role_id : UInt64 | Snowflake, reason : String? = nil)
-      headers = HTTP::Headers.new
-      headers["X-Audit-Log-Reason"] = reason if reason
-
+    def delete_guild_role(guild_id : UInt64 | Snowflake, role_id : UInt64 | Snowflake)
       request(
         :guilds_gid_roles_rid,
         guild_id,
         "DELETE",
         "/guilds/#{guild_id}/roles/#{role_id}",
-        headers,
+        HTTP::Headers.new,
         nil
       )
     end
@@ -1283,12 +1443,15 @@ module Discord
     # days. Requires the "Kick Members" permission.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#get-guild-prune-count)
-    def get_guild_prune_count(guild_id : UInt64 | Snowflake, days : UInt32)
+    def get_guild_prune_count(guild_id : UInt64 | Snowflake, days : UInt32 = 7, include_roles : Array(UInt64 | Snowflake)? = nil)
+      query = "days=#{days}"
+      query += "include_roles=#{include_roles.map(&.to_s).join(",")}" if include_roles
+
       response = request(
         :guilds_gid_prune,
         guild_id,
         "GET",
-        "/guilds/#{guild_id}/prune?days=#{days}",
+        "/guilds/#{guild_id}/prune?#{query}",
         HTTP::Headers.new,
         nil
       )
@@ -1298,21 +1461,24 @@ module Discord
 
     # Prunes all members from this guild which haven't been seen for more than
     # *days* days. Requires the "Kick Members" permission.
+    # For large guilds it's recommended to set the compute_prune_count option to false, forcing 'pruned' to null.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#begin-guild-prune)
-    def begin_guild_prune(guild_id : UInt64 | Snowflake, days : UInt32, reason : String? = nil)
-      headers = HTTP::Headers{
-        "Content-Type" => "application/json",
-      }
-      headers["X-Audit-Log-Reason"] = reason if reason
+    def begin_guild_prune(guild_id : UInt64 | Snowflake, days : UInt32 = 7, compute_prune_count : Bool? = nil, include_roles : Array(UInt64 | Snowflake)? = nil, reason : String? = nil)
+      json = encode_tuple(
+        days: days,
+        compute_prune_count: compute_prune_count,
+        include_roles: include_roles,
+        reson: reason,
+      )
 
       response = request(
         :guilds_gid_prune,
         guild_id,
         "POST",
         "/guilds/#{guild_id}/prune?days=#{days}",
-        headers,
-        nil
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
       )
 
       PruneCountResponse.from_json(response.body)
@@ -1335,6 +1501,22 @@ module Discord
       Array(VoiceRegion).from_json(response.body)
     end
 
+    # Returns a list of invite objects (with invite metadata) for the guild.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#get-guild-invites)
+    def get_guild_invites(guild_id : UInt64 | Snowflake)
+      response = request(
+        :guilds_gid_invites,
+        guild_id,
+        "GET",
+        "/guilds/#{guild_id}/invites",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Array(InviteMetadata).from_json(response.body)
+    end
+
     # Gets a list of integrations (Twitch, YouTube, etc.) for this guild.
     # Requires the "Manage Guild" permission.
     #
@@ -1355,6 +1537,8 @@ module Discord
     # Creates a new integration for this guild. Requires the "Manage Guild"
     # permission.
     #
+    # DEPRECATED: This method is not logner present in Discord documentation
+    #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#create-guild-integration)
     def create_guild_integration(guild_id : UInt64 | Snowflake, type : String, id : UInt64 | Snowflake)
       json = encode_tuple(
@@ -1374,6 +1558,8 @@ module Discord
 
     # Modifies an existing guild integration. Requires the "Manage Guild"
     # permission.
+    #
+    # DEPRECATED: This method is not logner present in Discord documentation
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#modify-guild-integration)
     def modify_guild_integration(guild_id : UInt64 | Snowflake, integration_id : UInt64 | Snowflake,
@@ -1412,6 +1598,8 @@ module Discord
 
     # Syncs an integration. Requires the "Manage Guild" permission.
     #
+    # DEPRECATED: This method is not logner present in Discord documentation
+    #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#sync-guild-integration)
     def sync_guild_integration(guild_id : UInt64 | Snowflake, integration_id : UInt64 | Snowflake)
       request(
@@ -1424,42 +1612,389 @@ module Discord
       )
     end
 
-    # Gets embed data for a guild. Requires the "Manage Guild" permission.
+    # Returns a guild widget object. Requires the "Manage Guild" permission.
     #
-    # [API docs for this method](https://discord.com/developers/docs/resources/guild#get-guild-embed)
-    def get_guild_embed(guild_id : UInt64 | Snowflake)
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#get-guild-widget-settings)
+    def get_guild_widget_settings(guild_id : UInt64 | Snowflake)
       response = request(
-        :guilds_gid_embed,
+        :guilds_gid_widget,
         guild_id,
         "GET",
-        "/guilds/#{guild_id}/embed",
+        "/guilds/#{guild_id}/widget",
         HTTP::Headers.new,
         nil
       )
 
-      GuildEmbed.from_json(response.body)
+      GuildWidgetSettings.from_json(response.body)
     end
 
-    # Modifies embed data for a guild. Requires the "Manage Guild" permission.
+    # Modify a guild widget object for the guild. Requires the "Manage Guild" permission.
     #
-    # [API docs for this method](https://discord.com/developers/docs/resources/guild#modify-guild-embed)
-    def modify_guild_embed(guild_id : UInt64 | Snowflake, enabled : Bool,
-                           channel_id : UInt64 | Snowflake)
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#modify-guild-widget)
+    def modify_guild_widget(guild_id : UInt64 | Snowflake, enabled : Bool? = nil, channel_id : UInt64 | Snowflake | Nil = nil)
       json = encode_tuple(
         enabled: enabled,
         channel_id: channel_id
       )
 
       response = request(
-        :guilds_gid_embed,
+        :guilds_gid_widget,
         guild_id,
         "PATCH",
-        "/guilds/#{guild_id}/embed",
+        "/guilds/#{guild_id}/widget",
         HTTP::Headers{"Content-Type" => "application/json"},
         json
       )
 
-      GuildEmbed.from_json(response.body)
+      GuildWidgetSettings.from_json(response.body)
+    end
+
+    # Returns the widget for the guild.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#get-guild-widget)
+    def get_guild_widget(guild_id : UInt64 | Snowflake)
+      response = request(
+        :guilds_gid_widgetjson,
+        guild_id,
+        "GET",
+        "/guilds/#{guild_id}/widget.json",
+        HTTP::Headers.new,
+        nil
+      )
+
+      GuildWidget.from_json(response.body)
+    end
+
+    # Gets the vanity URL of a guild. Requires the guild to be partnered.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#get-guild-vanity-url)
+    def get_guild_vanity_url(guild_id : UInt64 | Snowflake)
+      response = request(
+        :guilds_gid_vanityurl,
+        guild_id,
+        "GET",
+        "/guilds/#{guild_id}/vanity-url",
+        HTTP::Headers.new,
+        nil
+      )
+
+      GuildVanityURLResponse.from_json(response.body).code
+    end
+
+    # Sets the vanity URL on this guild. Requires the guild to be
+    # partnered.
+    #
+    # There are no API docs for this method.
+    def modify_guild_vanity_url(guild_id : UInt64 | Snowflake, code : String)
+      request(
+        :guilds_gid_vanityurl,
+        guild_id,
+        "PATCH",
+        "/guilds/#{guild_id}/vanity-url",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        {code: code}.to_json
+      )
+    end
+
+    # Returns the Welcome Screen object for the guild.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#get-guild-welcome-screen)
+    def get_guild_welcome_screen(guild_id : UInt64 | Snowflake)
+      response = request(
+        :guilds_gid_welcome_screen,
+        guild_id,
+        "GET",
+        "/guilds/#{guild_id}/welcome-screen",
+        HTTP::Headers.new,
+        nil
+      )
+
+      WelcomeScreen.from_json(response.body)
+    end
+
+    # Modify the guild's Welcome Screen. Requires the "Manage Guild" permission.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#modify-guild-welcome-screen)
+    def modify_guild_welcome_screen(guild_id : UInt64 | Snowflake, enabled : Bool? = nil, welcome_channels : Array(WelcomeChannel)? = nil, description : String? = nil)
+      json = encode_tuple(
+        enabled: enabled,
+        welcome_channels: welcome_channels,
+        description: description,
+      )
+
+      response = request(
+        :guilds_gid_welcome_screen,
+        guild_id,
+        "PATCH",
+        "/guilds/#{guild_id}/welcome-screen",
+        HTTP::Headers.new,
+        nil
+      )
+
+      WelcomeScreen.from_json(response.body)
+    end
+
+    #
+    # Resources -> Guild Templates
+    #
+
+    # Returns a guild template object for the given code.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild-template#get-guild-template)
+    def get_guild_template(template_code : String)
+      response = request(
+        :guilds_templates_tc,
+        nil,
+        "GET",
+        "/guilds/templates/#{template_code}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      GuildTemplate.from_json(response.body)
+    end
+
+    # Create a new guild based on a template.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild-template#create-guild-from-guild-template)
+    def create_guild_from_guild_template(template_code : String, name : String, icon : String? = nil)
+      json = encode_tuple(
+        name: name,
+        icon: icon,
+      )
+
+      response = request(
+        :guilds_templates_tc,
+        nil,
+        "POST",
+        "/guilds/templates/#{template_code}",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+
+      Guild.from_json(response.body)
+    end
+
+    # Returns an array of guild template objects. Requires the "Manage Guild" permission.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild-template#get-guild-templates)
+    def get_guild_templates(guild_id : UInt64 | Snowflake)
+      response = request(
+        :guilds_gid_templates,
+        guild_id,
+        "GET",
+        "/guilds/#{guild_id}/templates",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Array(GuildTemplate).from_json(response.body)
+    end
+
+    # Creates a template for the guild. Requires the "Manage Guild" permission.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild-template#create-guild-template)
+    def create_guild_templates(guild_id : UInt64 | Snowflake, name : String, description : String? = nil)
+      json = encode_tuple(
+        name: name,
+        description: description,
+      )
+
+      response = request(
+        :guilds_gid_templates,
+        guild_id,
+        "POST",
+        "/guilds/#{guild_id}/templates",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+
+      GuildTemplate.from_json(response.body)
+    end
+
+    # Syncs the template to the guild's current state. Requires the "Manage Guild" permission.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild-template#sync-guild-template)
+    def sync_guild_templates(guild_id : UInt64 | Snowflake, template_code : String)
+      response = request(
+        :guilds_gid_templates_tc,
+        guild_id,
+        "PUT",
+        "/guilds/#{guild_id}/templates/#{template_code}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      GuildTemplate.from_json(response.body)
+    end
+
+    # Modifies the template's metadata. Requires the "Manage Guild" permission.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild-template#modify-guild-template)
+    def modify_guild_templates(guild_id : UInt64 | Snowflake, template_code : String, name : String? = nil, description : String? = nil)
+      json = encode_tuple(
+        name: name,
+        description: description,
+      )
+
+      response = request(
+        :guilds_gid_templates_tc,
+        guild_id,
+        "PATCH",
+        "/guilds/#{guild_id}/templates/#{template_code}",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+
+      GuildTemplate.from_json(response.body)
+    end
+
+    # Deletes the template. Requires the "Manage Guild" permission.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild-template#delete-guild-template)
+    def delete_guild_templates(guild_id : UInt64 | Snowflake, template_code : String)
+      response = request(
+        :guilds_gid_templates_tc,
+        guild_id,
+        "DELETE",
+        "/guilds/#{guild_id}/templates/#{template_code}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      GuildTemplate.from_json(response.body)
+    end
+
+    #
+    # Resources -> Invite
+    #
+
+    # Returns an invite object for the given code.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/invite#get-invite)
+    def get_invite(code : String, with_counts : Bool? = nil, with_expiration : Bool? = nil)
+      query = with_counts ? "?with_counts=#{with_counts}" : ""
+      query += "&with_expiration=#{with_expiration}" if with_expiration
+      query = "?#{query[1..]}" if query != "" && query[0] != '?'
+      response = request(
+        :invites,
+        nil,
+        "GET",
+        "/invites/#{code}#{query}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Invite.from_json(response.body)
+    end
+
+    # Returns an invite object for the given code. Requires an "Manage Channels" or "Manage Guild" permission.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/invite#get-invite)
+    def delete_invite(code : String)
+      response = request(
+        :invites,
+        nil,
+        "DELETE",
+        "/invites/#{code}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Invite.from_json(response.body)
+    end
+
+    #
+    # Resources -> Stage Instance
+    #
+
+    # Creates a new Stage instance associated to a Stage channel.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/stage-instance#create-stage-instance)
+    def create_stage_instance(channel_id : UInt64 | Snowflake, topic : String, privacy_level : UInt8 | PrivacyLevel | Nil = PrivacyLevel::GuildOnly)
+      json = encode_tuple(
+        channel_id: channel_id,
+        topic: topic,
+        privacy_level: privacy_level,
+      )
+
+      response = request(
+        :stageinstances,
+        nil,
+        "POST",
+        "/stage-instances",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+    end
+
+    # Gets the stage instance associated with the Stage channel, if it exists.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/stage-instance#get-stage-instance)
+    def get_stage_instance(channel_id : UInt64 | Snowflake)
+      response = request(
+        :stageinstances_cid,
+        channel_id,
+        "GET",
+        "/stage-instances/#{channel_id}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      StageInstance.from_json(response.body)
+    end
+
+    # Updates fields of an existing Stage instance.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/stage-instance#update-stage-instance)
+    def update_stage_instance(channel_id : UInt64 | Snowflake, topic : String? = nil, privacy_level : UInt8 | PrivacyLevel | Nil = nil)
+      json = encode_tuple(
+        topic: topic,
+        privacy_level: privacy_level,
+      )
+
+      response = request(
+        :stageinstances_cid,
+        channel_id,
+        "PATCH",
+        "/stage-instances/#{channel_id}",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        nil
+      )
+    end
+
+    # Deletes the Stage instance.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance)
+    def delete_stage_instance(channel_id : UInt64 | Snowflake)
+      response = request(
+        :stageinstances_cid,
+        channel_id,
+        "DELETE",
+        "/stage-instances/#{channel_id}",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    #
+    # Resources -> User
+    #
+
+    # Gets the current bot user.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/user#get-current-user)
+    def get_current_user
+      response = request(
+        :users_me,
+        nil,
+        "GET",
+        "/users/@me",
+        HTTP::Headers.new,
+        nil
+      )
+
+      User.from_json(response.body)
     end
 
     # Gets a specific user by ID.
@@ -1471,22 +2006,6 @@ module Discord
         nil,
         "GET",
         "/users/#{user_id}",
-        HTTP::Headers.new,
-        nil
-      )
-
-      User.from_json(response.body)
-    end
-
-    # Gets the current bot user.
-    #
-    # [API docs for this method](https://discord.com/developers/docs/resources/user#get-current-user)
-    def get_current_user
-      response = request(
-        :users_me,
-        nil,
-        "GET",
-        "/users/@me",
         HTTP::Headers.new,
         nil
       )
@@ -1519,30 +2038,23 @@ module Discord
     # Gets a list of user guilds the current user is on.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/user#get-current-user-guilds)
-    def get_current_user_guilds(limit : Int32 = 100, before : UInt64 | Snowflake = 0_u64, after : UInt64 | Snowflake = 0_u64)
+    def get_current_user_guilds(limit : Int32 = 100, before : UInt64 | Snowflake | Nil = nil, after : UInt64 | Snowflake | Nil = nil)
       params = URI::Params.build do |form|
         form.add "limit", limit.to_s
-
-        if before > 0_u64
-          form.add "before", before.to_s
-        end
-
-        if after > 0_u64
-          form.add "after", after.to_s
-        end
+        form.add "before", before.to_s if before
+        form.add "after", after.to_s if after
       end
 
-      path = "/users/@me/guilds?#{params}"
       response = request(
         :users_me_guilds,
         nil,
         "GET",
-        path,
+        "/users/@me/guilds?#{params}",
         HTTP::Headers.new,
         nil
       )
 
-      Array(UserGuild).from_json(response.body)
+      Array(PartialGuild).from_json(response.body)
     end
 
     # Returns a `Paginator` over the current users guilds.
@@ -1551,10 +2063,8 @@ module Discord
     # `limit` number of guilds are observed, or the user has no further guilds.
     # Setting `limit` to `nil` will have the paginator continue to make requests
     # until all guilds are fetched in the given `direction`.
-    def page_current_user_guilds(start_id : UInt64 | Snowflake = 0_u64, limit : Int32? = 100,
-                                 direction : Paginator::Direction = Paginator::Direction::Down,
-                                 page_size : Int32 = 100)
-      Paginator(UserGuild).new(limit, direction) do |last_page|
+    def page_current_user_guilds(start_id : UInt64 | Snowflake = 0_u64, limit : Int32? = 100, direction : Paginator::Direction = Paginator::Direction::Down, page_size : Int32 = 100)
+      Paginator(PartialGuild).new(limit, direction) do |last_page|
         if direction.up?
           next_id = last_page.try &.first.id || start_id
           get_current_user_guilds(page_size, before: next_id)
@@ -1579,22 +2089,6 @@ module Discord
       )
     end
 
-    # Gets a list of DM channels the bot has access to.
-    #
-    # [API docs for this method](https://discord.com/developers/docs/resources/user#get-user-dms)
-    def get_user_dms
-      response = request(
-        :users_me_channels,
-        nil,
-        "GET",
-        "/users/@me/channels",
-        HTTP::Headers.new,
-        nil
-      )
-
-      Array(PrivateChannel).from_json(response.body)
-    end
-
     # Creates a new DM channel with a given recipient. If there was already one
     # before, it will be reopened.
     #
@@ -1610,6 +2104,24 @@ module Discord
       )
 
       PrivateChannel.from_json(response.body)
+    end
+
+    # Gets a list of DM channels the bot has access to.
+    #
+    # DEPRECATED: This method is not logner present in Discord documentation
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/user#get-user-dms)
+    def get_user_dms
+      response = request(
+        :users_me_channels,
+        nil,
+        "GET",
+        "/users/@me/channels",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Array(PrivateChannel).from_json(response.body)
     end
 
     # Gets a list of connections the user has set up (Twitch, YouTube, etc.)
@@ -1628,42 +2140,9 @@ module Discord
       Array(Connection).from_json(response.body)
     end
 
-    # Gets a specific invite by its code.
     #
-    # [API docs for this method](https://discord.com/developers/docs/resources/invite#get-invite)
-    def get_invite(code : String)
-      response = request(
-        :invites_code,
-        nil,
-        "GET",
-        "/invites/#{code}",
-        HTTP::Headers.new,
-        nil
-      )
-
-      Invite.from_json(response.body)
-    end
-
-    # Deletes (revokes) an invite. Requires the "Manage Channel" permission for
-    # the channel the invite is for, or the "Manage Server" permission for the
-    # server.
+    # Resources -> Voice
     #
-    # [API docs for this method](https://discord.com/developers/docs/resources/invite#delete-invite)
-    def delete_invite(code : String, reason : String? = nil)
-      headers = HTTP::Headers.new
-      headers["X-Audit-Log-Reason"] = reason if reason
-
-      response = request(
-        :invites_code,
-        nil,
-        "DELETE",
-        "/invites/#{code}",
-        headers,
-        nil
-      )
-
-      Invite.from_json(response.body)
-    end
 
     # Gets a list of voice regions newly created servers have access to.
     #
@@ -1681,60 +2160,18 @@ module Discord
       Array(VoiceRegion).from_json(response.body)
     end
 
-    # Get a webhook.
     #
-    # [API docs for this method](https://discord.com/developers/docs/resources/webhook#get-webhook).
-    def get_webhook(webhook_id : UInt64 | Snowflake)
-      response = request(
-        :webhooks_wid,
-        webhook_id,
-        "GET",
-        "/webhooks/#{webhook_id}",
-        HTTP::Headers.new,
-        nil
-      )
-      Webhook.from_json(response.body)
-    end
+    # Resources -> Webhook
+    #
 
-    # Get a webhook, with a token.
+    # Create a new webhook. Requires the "Manage Webhooks" permission.
     #
-    # [API docs for this method](https://discord.com/developers/docs/resources/webhook#get-webhook-with-token).
-    def get_webhook(webhook_id : UInt64 | Snowflake, token : String)
-      response = request(
-        :webhooks_wid,
-        webhook_id,
-        "GET",
-        "/webhooks/#{webhook_id}/#{token}",
-        HTTP::Headers.new,
-        nil
-      )
-      Webhook.from_json(response.body)
-    end
-
-    # Get an array of guild webhooks.
-    #
-    # [API docs for this method](https://discord.com/developers/docs/resources/webhook#get-guild-webhooks).
-    def get_guild_webhooks(guild_id : UInt64 | Snowflake)
-      response = request(
-        :guilds_gid_webhooks,
-        guild_id,
-        "GET",
-        "/guilds/#{guild_id}/webhooks",
-        HTTP::Headers.new,
-        nil
-      )
-      Array(Webhook).from_json(response.body)
-    end
-
-    # Create a channel webhook.
-    #
-    # [API docs for this method](https://discord.com/developers/docs/resources/webhook#create-webhook).
-    def create_channel_webhook(channel_id : UInt64 | Snowflake, name : String,
-                               avatar : String)
-      json = {
-        name:   name,
+    # [API docs for this method](https://discord.com/developers/docs/resources/webhook#create-webhook)
+    def create_webhook(channel_id : UInt64 | Snowflake, name : String, avatar : String? = nil)
+      json = encode_tuple(
+        name: name,
         avatar: avatar,
-      }.to_json
+      )
 
       response = request(
         :channels_cid_webhooks,
@@ -1764,6 +2201,51 @@ module Discord
       Array(Webhook).from_json(response.body)
     end
 
+    # Get an array of guild webhooks.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/webhook#get-guild-webhooks).
+    def get_guild_webhooks(guild_id : UInt64 | Snowflake)
+      response = request(
+        :guilds_gid_webhooks,
+        guild_id,
+        "GET",
+        "/guilds/#{guild_id}/webhooks",
+        HTTP::Headers.new,
+        nil
+      )
+      Array(Webhook).from_json(response.body)
+    end
+
+    # Get a webhook.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/webhook#get-webhook)
+    def get_webhook(webhook_id : UInt64 | Snowflake)
+      response = request(
+        :webhooks_wid,
+        webhook_id,
+        "GET",
+        "/webhooks/#{webhook_id}",
+        HTTP::Headers.new,
+        nil
+      )
+      Webhook.from_json(response.body)
+    end
+
+    # Get a webhook, with a token.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/webhook#get-webhook-with-token).
+    def get_webhook(webhook_id : UInt64 | Snowflake, token : String)
+      response = request(
+        :webhooks_wid,
+        webhook_id,
+        "GET",
+        "/webhooks/#{webhook_id}/#{token}",
+        HTTP::Headers.new,
+        nil
+      )
+      Webhook.from_json(response.body)
+    end
+
     # Modify a webhook. Accepts optional parameters `name`, `avatar`, and `channel_id`.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/webhook#modify-webhook).
@@ -1772,7 +2254,7 @@ module Discord
       json = encode_tuple(
         name: name,
         avatar: avatar,
-        channel_id: channel_id
+        channel_id: channel_id,
       )
 
       response = request(
@@ -1794,7 +2276,7 @@ module Discord
                                   avatar : String? = nil)
       json = encode_tuple(
         name: name,
-        avatar: avatar
+        avatar: avatar,
       )
 
       response = request(
@@ -1841,29 +2323,493 @@ module Discord
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/webhook#execute-webhook)
     def execute_webhook(webhook_id : UInt64 | Snowflake, token : String, content : String? = nil,
-                        file : String? = nil, embeds : Array(Embed)? = nil,
-                        tts : Bool? = nil, avatar_url : String? = nil,
-                        username : String? = nil, wait : Bool? = false)
-      json = encode_tuple(
+                        embeds : Array(Embed)? = nil, file : String | IO | Nil = nil,
+                        filename : String? = nil, tts : Bool? = nil, avatar_url : String? = nil,
+                        username : String? = nil, allowed_mentions : AllowedMentions? = nil,
+                        components : Array(Component)? = nil, wait : Bool? = false)
+      body = encode_tuple(
         content: content,
-        file: file,
-        embeds: embeds,
-        tts: tts,
+        username: username,
         avatar_url: avatar_url,
-        username: username
+        tts: tts,
+        embeds: embeds,
+        allowed_mentions: allowed_mentions,
+        components: components,
       )
+
+      content_type = "application/json"
+      body, content_type = send_file(body, file, filename) if file
 
       response = request(
         :webhooks_wid,
         webhook_id,
         "POST",
-        "/webhooks/#{webhook_id}/#{token}?wait=#{wait}",
-        HTTP::Headers{"Content-Type" => "application/json"},
-        json
+        "/webhooks/#{webhook_id}/#{token}#{wait ? "?wait=#{wait}" : ""}",
+        HTTP::Headers{"Content-Type" => content_type},
+        body
       )
 
       # Expecting response
       Message.from_json(response.body) if wait
+    end
+
+    # Returns a previously-sent webhook message from the same token.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/webhook#get-webhook-message)
+    def get_webhook_message(webhook_id : UInt64 | Snowflake, token : String, message_id : UInt64 | Snowflake)
+      response = request(
+        :webhooks_wid_t_messages_mid,
+        webhook_id,
+        "GET",
+        "/webhooks/#{webhook_id}/#{token}/messages/#{message_id}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Message.from_json(response.body)
+    end
+
+    # Edits a previously-sent webhook message from the same token.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/webhook#get-webhook-message)
+    def edit_webhook_message(webhook_id : UInt64 | Snowflake, token : String, message_id : UInt64 | Snowflake,
+                             content : String? = nil, embeds : Array(Embed)? = nil,
+                             file : String | IO | Nil = nil, filename : String? = nil,
+                             allowed_mentions : AllowedMentions? = nil, components : Array(Component)? = nil)
+      body = encode_tuple(
+        content: content,
+        embeds: embeds,
+        allowed_mentions: allowed_mentions,
+        components: components,
+      )
+
+      content_type = "application/json"
+      body, content_type = send_file(body, file, filename) if file
+
+      response = request(
+        :webhooks_wid_t_messages_mid,
+        webhook_id,
+        "PATCH",
+        "/webhooks/#{webhook_id}/#{token}/messages/#{message_id}",
+        HTTP::Headers{"Content-Type" => content_type},
+        body
+      )
+
+      Message.from_json(response.body)
+    end
+
+    # Deletes a message that was created by the webhook.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/webhook#delete-webhook-message)
+    def delete_webhook_message(webhook_id : UInt64 | Snowflake, token : String, message_id : UInt64 | Snowflake)
+      response = request(
+        :webhooks_wid_t_messages_mid,
+        webhook_id,
+        "DELETE",
+        "/webhooks/#{webhook_id}/#{token}/messages/#{message_id}",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    #
+    # Interactions -> Slash Commands
+    #
+
+    # Fetch all of the global commands for your application.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#get-global-application-commands)
+    def get_global_application_commands(application_id : UInt64 | Snowflake)
+      response = request(
+        :applications_aid_commands,
+        application_id,
+        "GET",
+        "/applications/#{application_id}/commands",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Array(ApplicationCommand).from_json(response.body)
+    end
+
+    # Create a new global command. New global commands will be available in all guilds after 1 hour.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command)
+    def create_global_application_command(application_id : UInt64 | Snowflake, name : String, description : String,
+                                          options : Array(ApplicationCommandOption)? = nil, default_permission : Bool? = nil)
+      json = encode_tuple(
+        name: name,
+        description: description,
+        options: options,
+        default_permission: default_permission,
+      )
+
+      response = request(
+        :applications_aid_commands,
+        application_id,
+        "POST",
+        "/applications/#{application_id}/commands",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+
+      ApplicationCommand.from_json(response.body)
+    end
+
+    # Fetch a global command for your application.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#get-global-application-command)
+    def get_global_application_command(application_id : UInt64 | Snowflake, command_id : UInt64 | Snowflake)
+      response = request(
+        :applications_aid_commands_cid,
+        application_id,
+        "GET",
+        "/applications/#{application_id}/commands/#{command_id}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      ApplicationCommand.from_json(response.body)
+    end
+
+    # Edit a global command. Updates will be available in all guilds after 1 hour.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command)
+    def edit_global_application_command(application_id : UInt64 | Snowflake, command_id : UInt64 | Snowflake,
+                                        name : String? = nil, description : String? = nil,
+                                        options : Array(ApplicationCommandOption)? = nil, default_permission : Bool? = nil)
+      json = encode_tuple(
+        name: name,
+        description: description,
+        options: options,
+        default_permission: default_permission,
+      )
+
+      response = request(
+        :applications_aid_commands_cid,
+        application_id,
+        "PATCH",
+        "/applications/#{application_id}/commands/#{command_id}",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+
+      ApplicationCommand.from_json(response.body)
+    end
+
+    # Deletes a global command.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#delete-global-application-command)
+    def delete_global_application_command(application_id : UInt64 | Snowflake, command_id : UInt64 | Snowflake)
+      response = request(
+        :applications_aid_commands_cid,
+        application_id,
+        "DELETE",
+        "/applications/#{application_id}/commands/#{command_id}",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    # Fetch all of the guild commands for your application for a specific guild.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#get-guild-application-commands)
+    def get_guild_application_commands(application_id : UInt64 | Snowflake, guild_id : UInt64 | Snowflake)
+      response = request(
+        :applications_aid_guilds_gid_commands,
+        application_id,
+        "GET",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Array(ApplicationCommand).from_json(response.body)
+    end
+
+    # Takes a list of application commands, overwriting existing commands that are registered globally for this application. Updates will be available in all guilds after 1 hour.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#bulk-overwrite-global-application-commands)
+    def bulk_overwrite_global_application_commands(application_id : UInt64 | Snowflake, commands : Array(PartialApplicationCommand))
+      response = request(
+        :applications_aid_commands,
+        application_id,
+        "PUT",
+        "/applications/#{application_id}/commands",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        commands.to_json
+      )
+
+      Array(ApplicationCommand).from_json(response.body)
+    end
+
+    # Create a new guild command. New guild commands will be available in the guild immediately.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command)
+    def create_guild_application_command(application_id : UInt64 | Snowflake, guild_id : UInt64 | Snowflake, name : String, description : String,
+                                         options : Array(ApplicationCommandOption)? = nil, default_permission : Bool? = nil)
+      json = encode_tuple(
+        name: name,
+        description: description,
+        options: options,
+        default_permission: default_permission,
+      )
+
+      response = request(
+        :applications_aid_guilds_gid_commands,
+        application_id,
+        "POST",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+
+      ApplicationCommand.from_json(response.body)
+    end
+
+    # Fetch a guild command for your application.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#get-guild-application-command)
+    def get_guild_application_command(application_id : UInt64 | Snowflake, guild_id : UInt64 | Snowflake, command_id : UInt64 | Snowflake)
+      response = request(
+        :applications_aid_guilds_gid_commands_cid,
+        application_id,
+        "GET",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      ApplicationCommand.from_json(response.body)
+    end
+
+    # Edit a guild command. Updates for guild commands will be available immediately.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command)
+    def edit_guild_application_command(application_id : UInt64 | Snowflake, guild_id : UInt64 | Snowflake, command_id : UInt64 | Snowflake,
+                                       name : String? = nil, description : String? = nil,
+                                       options : Array(ApplicationCommandOption)? = nil, default_permission : Bool? = nil)
+      json = encode_tuple(
+        name: name,
+        description: description,
+        options: options,
+        default_permission: default_permission,
+      )
+
+      response = request(
+        :applications_aid_guilds_gid_commands_cid,
+        application_id,
+        "PATCH",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+
+      ApplicationCommand.from_json(response.body)
+    end
+
+    # Delete a guild command.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#delete-guild-application-command)
+    def delete_guild_application_command(application_id : UInt64 | Snowflake, guild_id : UInt64 | Snowflake, command_id : UInt64 | Snowflake)
+      response = request(
+        :applications_aid_guilds_gid_commands_cid,
+        application_id,
+        "DELETE",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    # Takes a list of application commands, overwriting existing commands for the guild.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#bulk-overwrite-guild-application-commands)
+    def bulk_overwrite_guild_application_command(application_id : UInt64 | Snowflake, guild_id : UInt64 | Snowflake, commands : Array(PartialApplicationCommand))
+      response = request(
+        :applications_aid_guilds_gid_commands,
+        application_id,
+        "PUT",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        commands.to_json
+      )
+
+      Array(ApplicationCommand).from_json(response.body)
+    end
+
+    # Create a response to an Interaction from the gateway.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#create-interaction-response)
+    def create_interaction_response(interaction_id : UInt64 | Snowflake, token : String, response : InteractionResponse)
+      response = request(
+        :interactions_iid_t_callback,
+        interaction_id,
+        "POST",
+        "/interactions/#{interaction_id}/#{token}/callback",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        response.to_json
+      )
+    end
+
+    # Returns the initial Interaction response.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#get-original-interaction-response)
+    def get_original_interaction_response(application_id : UInt64 | Snowflake, token : String)
+      response = request(
+        :webhooks_aid_t_messages_original,
+        application_id,
+        "GET",
+        "/webhooks/#{application_id}/#{token}/messages/@original",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Message.from_json(response.body)
+    end
+
+    # Edits the initial Interaction response.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response)
+    def edit_original_interaction_response(application_id : UInt64 | Snowflake, token : String,
+                                           content : String? = nil, embeds : Array(Embed)? = nil,
+                                           file : String | IO | Nil = nil, filename : String? = nil,
+                                           allowed_mentions : AllowedMentions? = nil, components : Array(Component)? = nil)
+      body = encode_tuple(
+        content: content,
+        embeds: embeds,
+        allowed_mentions: allowed_mentions,
+        components: components,
+      )
+
+      content_type = "application/json"
+      body, content_type = send_file(body, file, filename) if file
+
+      response = request(
+        :webhooks_aid_t_messages_original,
+        application_id,
+        "PATCH",
+        "/webhooks/#{application_id}/#{token}/messages/@original",
+        HTTP::Headers{"Content-Type" => content_type},
+        body
+      )
+
+      Message.from_json(response.body)
+    end
+
+    # Deletes the initial Interaction response.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#delete-original-interaction-response)
+    def delete_original_interaction_response(application_id : UInt64 | Snowflake, token : String)
+      response = request(
+        :webhooks_aid_t_messages_original,
+        application_id,
+        "DELETE",
+        "/webhooks/#{application_id}/#{token}/messages/@original",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    # Create a followup message for an Interaction.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#create-followup-message)
+    def create_followup_message(application_id : UInt64 | Snowflake, token : String, content : String? = nil,
+                                embeds : Array(Embed)? = nil, file : String | IO | Nil = nil,
+                                filename : String? = nil, tts : Bool? = nil, avatar_url : String? = nil,
+                                username : String? = nil, allowed_mentions : AllowedMentions? = nil,
+                                components : Array(Component)? = nil, wait : Bool? = false)
+      execute_webhook(application_id, token, content, file, filename, embeds, tts, nil, nil, allowed_mentions, components, true)
+    end
+
+    # Edits a followup message for an Interaction.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message)
+    def edit_followup_message(application_id : UInt64 | Snowflake, token : String, message_id : UInt64 | Snowflake,
+                              content : String? = nil, embeds : Array(Embed)? = nil,
+                              file : String | IO | Nil = nil, filename : String? = nil,
+                              allowed_mentions : AllowedMentions? = nil, components : Array(Component)? = nil)
+      edit_webhook_message(application_id, token, message_id, file, filename, content, embeds, allowed_mentions, components)
+    end
+
+    # Deletes a followup message for an Interaction.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#delete-followup-message)
+    def delete_followup_message(application_id : UInt64 | Snowflake, token : String, message_id : UInt64 | Snowflake)
+      response = request(
+        :webhooks_aid_t_messages_mid,
+        application_id,
+        "DELETE",
+        "/webhooks/#{application_id}/#{token}/messages/#{message_id}",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    # Fetches command permissions for all commands for your application in a guild.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#get-guild-application-command-permissions)
+    def get_guild_application_command_permissions(application_id : UInt64 | Snowflake, guild_id : UInt64 | Snowflake)
+      response = request(
+        :applications_aid_guilds_gid_commands_permissions,
+        application_id,
+        "GET",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/permissions",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Array(GuildApplicationCommandPermissions).from_json(response.body)
+    end
+
+    # Fetches command permissions for a specific command for your application in a guild.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#get-application-command-permissions)
+    def get_application_command_permissions(application_id : UInt64 | Snowflake, guild_id : UInt64 | Snowflake, command_id : UInt64 | Snowflake)
+      response = request(
+        :applications_aid_guilds_gid_commands_cid_permissions,
+        application_id,
+        "GET",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}/permissions",
+        HTTP::Headers.new,
+        nil
+      )
+
+      GuildApplicationCommandPermissions.from_json(response.body)
+    end
+
+    # Edits command permissions for a specific command for your application in a guild. You can only add up to 10 permission overwrites for a command.
+    #
+    # NOTE: This endpoint will overwrite existing permissions for the command in that guild
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#edit-application-command-permissions)
+    def edit_application_command_permissions(application_id : UInt64 | Snowflake, guild_id : UInt64 | Snowflake, command_id : UInt64 | Snowflake, permissions : Array(ApplicationCommandPermissions))
+      response = request(
+        :applications_aid_guilds_gid_commands_cid_permissions,
+        application_id,
+        "PUT",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}/permissions",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        {permissions: permissions}.to_json
+      )
+    end
+
+    # Batch edits permissions for all commands in a guild. Takes an array of partial GuildApplicationCommandPermissions objects including id and permissions.
+    # You can only add up to 10 permission overwrites for a command.
+    #
+    # NOTE: This endpoint will overwrite all existing permissions for all commands in a guild
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#batch-edit-application-command-permissions)
+    def batch_edit_application_command_permissions(application_id : UInt64 | Snowflake, guild_id : UInt64 | Snowflake, permissions : Hash(UInt64 | Snowflake, Array(ApplicationCommandPermissions)))
+      json = permissions.map { |cid, perm| {"id" => cid, "permissions" => perm} }
+      response = request(
+        :applications_aid_guilds_gid_commands_permissions,
+        application_id,
+        "PUT",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/permissions",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json.to_json
+      )
     end
   end
 end

--- a/src/discordcr/version.cr
+++ b/src/discordcr/version.cr
@@ -1,3 +1,4 @@
 module Discord
-  VERSION = "0.4.0"
+  VERSION     = "0.5.0"
+  API_VERSION = "8"
 end

--- a/src/discordcr/voice.cr
+++ b/src/discordcr/voice.cr
@@ -1,9 +1,4 @@
-require "uri"
-
-require "./mappings/gateway"
-require "./mappings/vws"
 require "./websocket"
-require "./sodium"
 
 module Discord
   class VoiceClient


### PR DESCRIPTION
REST and other changes from PR #18 

This PR contains all the changes I did other than models.
Note that these changes **will not compile** without the model changes.

Changes in this PR:
- Updated REST methods
- Updated Gateway events
- Added `DEFAULT_INTENTS` to `Discord::Client`
- Added `initial_presence` to `Discord::Client`, to allow sending presence data with the Identify packet
- When `Discord::CodeException` is thrown, human-readable errors are shown along with the exception
- 5 REST modify methods now support sending null
- Every REST method that supports sending files now can actually send files
- Added REST spec for most of the methods

From the original PR, I've removed the code from `client.cr` belonging to the Stage Instances because the PR #12 way better implements it.

The 5 REST modify methods I was referencing earlier are:
- `#modify_channel`
- `#modify_guild_emoji`
- `#modify_guild`
- `#modify_guild_member`
- `#modify_guild_role`

Their definitions now look like:
```crystal
def modify_guild(guild_id : UInt64 | Snowflake, reason : String? = nil, **args : **T) forall T
```
You can find a `Hash(Symbol, TypeCheck.class)` beneath every method that dictates the valid names and types of arguments.
Due to this change, you now have to specify arguments by their names, but you can now send a null value.
Example:
```crystal
CLIENT.modify_guild(1234567890, "Test Guild") # Will do nothing, and "Test Guild" will be put into the reason
CLIENT.modify_guild(1234567890, name: "Test Guild") # Will change the name of the guild to "Test Guild"
```