### PR TITLE
Move to API v9 and add threads support

### DIFF
--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -102,7 +102,7 @@ module Discord
                    @compress : CompressMode = CompressMode::Stream,
                    @zlib_buffer_size : Int32 = 10 * 1024 * 1024,
                    @properties : Gateway::IdentifyProperties = DEFAULT_PROPERTIES,
-                   @intents : Gateway::Intents? = nil)
+                   @intents : Gateway::Intents? = Gateway::Intents::Unprivileged)
       @backoff = 1.0
 
       # Set some default value for the heartbeat interval. This should never

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -36,12 +36,12 @@ module Discord
     ThreeDays =  4320
     Week      = 10080
 
-    def to_json(json : JSON::Builder)
-      json.number(value)
-    end
-
     def self.new(pull : JSON::PullParser)
       AutoArchiveDuration.new(pull.read_int.to_u16)
+    end
+
+    def to_json(json : JSON::Builder)
+      json.number(value)
     end
   end
 
@@ -71,7 +71,7 @@ module Discord
     property thread : Channel?
     property referenced_message : Message?
 
-    def to_message_reference : MessageReference
+    def message_reference : MessageReference
       MessageReference.new(@id, @channel_id, @guild_id)
     end
   end
@@ -123,6 +123,10 @@ module Discord
     def self.new(pull : JSON::PullParser)
       ChannelType.new(pull.read_int.to_u8)
     end
+
+    def to_json(json : JSON::Builder)
+      json.number(value)
+    end
   end
 
   struct Channel
@@ -149,6 +153,7 @@ module Discord
     property message_count : UInt32?
     property member_count : UInt32?
     property member : ThreadMember?
+    property default_auto_archive_duration : AutoArchiveDuration?
     property last_message_id : Snowflake?
 
     # :nodoc:

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -227,6 +227,7 @@ module Discord
       property explicit_content_filter : UInt8
       property system_channel_id : Snowflake?
       property stage_instances : Array(StageInstance)
+      property threads : Array(Channel)
 
       {% unless flag?(:correct_english) %}
         def emojis
@@ -411,9 +412,7 @@ module Discord
       include JSON::Serializable
 
       property user : PartialUser
-      property roles : Array(Snowflake)
       property game : GamePlaying?
-      property nick : String?
       property guild_id : Snowflake
       property status : String
       property activities : Array(GamePlaying)
@@ -451,6 +450,25 @@ module Discord
       @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
       property last_pin_timestamp : Time?
       property channel_id : Snowflake
+    end
+
+    struct ThreadMembersUpdatePayload
+      include JSON::Serializable
+
+      property id : Snowflake
+      property guild_id : Snowflake
+      property member_count : UInt32
+      property added_members : Array(ThreadMember)?
+      property removed_member_ids : Array(Snowflake)?
+    end
+
+    struct ThreadListSyncPayload
+      include JSON::Serializable
+
+      property guild_id : Snowflake
+      property channel_ids : Array(Snowflake)?
+      property threads : Array(Channel)
+      property members : Array(ThreadMember)
     end
   end
 end

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -84,6 +84,11 @@ module Discord
       DirectMessages         = 1 << 12
       DirectMessageReactions = 1 << 13
       DirectMessageTyping    = 1 << 14
+
+      # Generates an Unprivileged intents constant, removing GuildMembers and GuildPresences.
+      {% begin %}
+        Unprivileged = {{ @type.constants.reject { |e| ["All", "None", "GuildMembers", "GuildPresences"].includes?(e.stringify) }.join("|").id }}
+      {% end %}
     end
 
     struct ResumePacket

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -13,8 +13,9 @@ module Discord
     property region : String
     property afk_channel_id : Snowflake?
     property afk_timeout : Int32?
-    property embed_enabled : Bool?
-    property embed_channel_id : Snowflake?
+    # Removed in v8
+    # property embed_enabled : Bool?
+    # property embed_channel_id : Snowflake?
     property verification_level : UInt8
     property premium_tier : UInt8
     property premium_subscription_count : UInt8?
@@ -93,7 +94,7 @@ module Discord
 
     property user : User
     property nick : String?
-    property roles : Array(Snowflake)
+    property roles : Array(Snowflake)?
     @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
     property joined_at : Time?
     @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
@@ -133,8 +134,6 @@ module Discord
     # :nodoc:
     def initialize(payload : Gateway::PresenceUpdatePayload)
       @user = User.new(payload.user)
-      @nick = payload.nick
-      @roles = payload.roles
       # Presence updates have no joined_at or deaf/mute, thanks Discord
     end
 

--- a/src/discordcr/mappings/permissions.cr
+++ b/src/discordcr/mappings/permissions.cr
@@ -1,40 +1,44 @@
 module Discord
   @[Flags]
   enum Permissions : UInt64
-    CreateInstantInvite = 1
-    KickMembers         = 1 << 1
-    BanMembers          = 1 << 2
-    Administrator       = 1 << 3
-    ManageChannels      = 1 << 4
-    ManageGuild         = 1 << 5
-    AddReactions        = 1 << 6
-    ViewAuditLog        = 1 << 7
-    PrioritySpeaker     = 1 << 8
-    Stream              = 1 << 9
-    ReadMessages        = 1 << 10
-    SendMessages        = 1 << 11
-    SendTTSMessages     = 1 << 12
-    ManageMessages      = 1 << 13
-    EmbedLinks          = 1 << 14
-    AttachFiles         = 1 << 15
-    ReadMessageHistory  = 1 << 16
-    MentionEveryone     = 1 << 17
-    UseExternalEmojis   = 1 << 18
-    Connect             = 1 << 20
-    Speak               = 1 << 21
-    MuteMembers         = 1 << 22
-    DeafenMembers       = 1 << 23
-    MoveMembers         = 1 << 24
-    UseVAD              = 1 << 25
-    ChangeNickname      = 1 << 26
-    ManageNicknames     = 1 << 27
-    ManageRoles         = 1 << 28
-    ManageWebhooks      = 1 << 29
-    ManageEmojis        = 1 << 30
-    RequestToSpeak      = 1 << 32
+    CreateInstantInvite    = 1
+    KickMembers            = 1 << 1
+    BanMembers             = 1 << 2
+    Administrator          = 1 << 3
+    ManageChannels         = 1 << 4
+    ManageGuild            = 1 << 5
+    AddReactions           = 1 << 6
+    ViewAuditLog           = 1 << 7
+    PrioritySpeaker        = 1 << 8
+    Stream                 = 1 << 9
+    ReadMessages           = 1 << 10
+    SendMessages           = 1 << 11
+    SendTTSMessages        = 1 << 12
+    ManageMessages         = 1 << 13
+    EmbedLinks             = 1 << 14
+    AttachFiles            = 1 << 15
+    ReadMessageHistory     = 1 << 16
+    MentionEveryone        = 1 << 17
+    UseExternalEmojis      = 1 << 18
+    Connect                = 1 << 20
+    Speak                  = 1 << 21
+    MuteMembers            = 1 << 22
+    DeafenMembers          = 1 << 23
+    MoveMembers            = 1 << 24
+    UseVAD                 = 1 << 25
+    ChangeNickname         = 1 << 26
+    ManageNicknames        = 1 << 27
+    ManageRoles            = 1 << 28
+    ManageWebhooks         = 1 << 29
+    ManageEmojis           = 1 << 30
+    UseApplicationCommands = 1 << 31
+    RequestToSpeak         = 1 << 32
+    ManageThreads          = 1 << 34
+    UsePrivateThreads      = 1 << 36
+    UseExternalStickers    = 1 << 37
 
     def self.new(pull : JSON::PullParser)
-      Permissions.new(pull.read_int.to_u64)
+      Permissions.new(pull.read_string.to_u64)
     end
 
     def to_json(json : JSON::Builder)

--- a/src/discordcr/mappings/rest.cr
+++ b/src/discordcr/mappings/rest.cr
@@ -85,5 +85,14 @@ module Discord
         @id = id
       end
     end
+
+    # Response payload to a thread list request
+    struct ThreadsPayload
+      include JSON::Serializable
+
+      property threads : Array(Channel)
+      property members : Array(ThreadMember)
+      property has_more : Bool
+    end
   end
 end

--- a/src/discordcr/mappings/rest.cr
+++ b/src/discordcr/mappings/rest.cr
@@ -92,7 +92,7 @@ module Discord
 
       property threads : Array(Channel)
       property members : Array(ThreadMember)
-      property has_more : Bool
+      property has_more : Bool?
     end
   end
 end

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -1059,9 +1059,10 @@ module Discord
     # permission.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#create-guild-channel)
-    def create_guild_channel(guild_id : UInt64 | Snowflake, name : String, type : ChannelType, topic : String?,
-                             bitrate : UInt32?, user_limit : UInt32?, rate_limit_per_user : Int32?,
-                             position : UInt32?, parent_id : UInt64? | Snowflake?, nsfw : Bool?, reason : String? = nil)
+    def create_guild_channel(guild_id : UInt64 | Snowflake, name : String, type : ChannelType, topic : String? = nil,
+                             bitrate : UInt32? = nil, user_limit : UInt32? = nil, rate_limit_per_user : Int32? = nil,
+                             position : UInt32? = nil, parent_id : UInt64? | Snowflake? = nil, nsfw : Bool? = nil,
+                             reason : String? = nil)
       json = encode_tuple(
         name: name,
         type: type,

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -178,7 +178,9 @@ module Discord
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#modify-channel)
     def modify_channel(channel_id : UInt64 | Snowflake, name : String? = nil, position : UInt32? = nil,
                        topic : String? = nil, bitrate : UInt32? = nil, user_limit : UInt32? = nil,
-                       nsfw : Bool? = nil, rate_limit_per_user : Int32? = nil, default_auto_archive_duration : AutoArchiveDuration? = nil)
+                       nsfw : Bool? = nil, rate_limit_per_user : Int32? = nil,
+                       default_auto_archive_duration : AutoArchiveDuration? = nil, archived : Bool? = nil,
+                       locked : Bool? = nil, invitable : Bool? = nil)
       json = encode_tuple(
         name: name,
         position: position,
@@ -187,7 +189,10 @@ module Discord
         user_limit: user_limit,
         nsfw: nsfw,
         rate_limit_per_user: rate_limit_per_user,
-        default_auto_archive_duration: default_auto_archive_duration
+        default_auto_archive_duration: default_auto_archive_duration,
+        archived: archived,
+        locked: locked,
+        invitable: invitable
       )
 
       response = request(
@@ -334,7 +339,8 @@ module Discord
     # The id of the created thread will be the same as the id of the message, and as such a message can only have a single thread created from it.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#start-thread-with-message)
-    def start_thread(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake, name : String, auto_archive_duration : AutoArchiveDuration, reason : String? = nil)
+    def start_thread(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake, name : String,
+                     auto_archive_duration : AutoArchiveDuration, reason : String? = nil)
       json = encode_tuple(
         name: name,
         auto_archive_duration: auto_archive_duration
@@ -353,7 +359,6 @@ module Discord
         headers,
         json
       )
-      pp response
 
       Channel.from_json(response.body)
     end
@@ -362,7 +367,8 @@ module Discord
     # Creates a new thread that is not connected to an existing message.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#start-thread-without-message)
-    def start_thread(channel_id : UInt64 | Snowflake, name : String, auto_archive_duration : AutoArchiveDuration, type : ChannelType? = nil, invitable : Bool? = nil, reason : String? = nil)
+    def start_thread(channel_id : UInt64 | Snowflake, name : String, auto_archive_duration : AutoArchiveDuration,
+                     type : ChannelType? = ChannelType::GuildPublicThread, invitable : Bool? = nil, reason : String? = nil)
       json = encode_tuple(
         name: name,
         auto_archive_duration: auto_archive_duration,
@@ -467,13 +473,13 @@ module Discord
 
     # List Active Threads
     #
-    # [API docs for this method](https://discord.com/developers/docs/resources/channel#list-active-threads)
-    def list_active_threads(channel_id : UInt64 | Snowflake)
+    # [API docs for this method](https://discord.com/developers/docs/resources/guild#list-active-threads)
+    def list_active_threads(guild_id : UInt64 | Snowflake)
       response = request(
-        :channel_cid_threads,
-        channel_id,
+        :guild_gid_threads,
+        guild_id,
         "GET",
-        "/channels/#{channel_id}/threads/active",
+        "/guilds/#{guild_id}/threads/active",
         HTTP::Headers.new,
         nil
       )
@@ -1753,7 +1759,7 @@ module Discord
     end
 
     # Gets embed data for a guild. Requires the "Manage Guild" permission.
-    # TODO Did this move to /widget?
+    #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#get-guild-embed)
     def get_guild_embed(guild_id : UInt64 | Snowflake)
       response = request(

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -11,7 +11,7 @@ module Discord
   module REST
     SSL_CONTEXT = OpenSSL::SSL::Context::Client.new
     USER_AGENT  = "DiscordBot (https://github.com/discordcr/discordcr, #{Discord::VERSION})"
-    API_BASE    = "https://discord.com/api/v6"
+    API_BASE    = "https://discord.com/api/v9"
 
     Log = Discord::Log.for("rest")
 
@@ -178,7 +178,7 @@ module Discord
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#modify-channel)
     def modify_channel(channel_id : UInt64 | Snowflake, name : String? = nil, position : UInt32? = nil,
                        topic : String? = nil, bitrate : UInt32? = nil, user_limit : UInt32? = nil,
-                       nsfw : Bool? = nil, rate_limit_per_user : Int32? = nil)
+                       nsfw : Bool? = nil, rate_limit_per_user : Int32? = nil, default_auto_archive_duration : AutoArchiveDuration? = nil)
       json = encode_tuple(
         name: name,
         position: position,
@@ -186,7 +186,8 @@ module Discord
         bitrate: bitrate,
         user_limit: user_limit,
         nsfw: nsfw,
-        rate_limit_per_user: rate_limit_per_user
+        rate_limit_per_user: rate_limit_per_user,
+        default_auto_archive_duration: default_auto_archive_duration
       )
 
       response = request(
@@ -201,7 +202,7 @@ module Discord
       Channel.from_json(response.body)
     end
 
-    # Deletes a channel by ID. Requires the "Manage Channel" permission.
+    # Deletes a channel by ID. Requires the "Manage Channel" permission, or "Manage Threads" if the channel is a thread.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#deleteclose-channel)
     def delete_channel(channel_id : UInt64 | Snowflake)
@@ -306,12 +307,13 @@ module Discord
     # For more details on the format of the `embed` object, look at the
     # [relevant documentation](https://discord.com/developers/docs/resources/channel#embed-object).
     def create_message(channel_id : UInt64 | Snowflake, content : String, embed : Embed? = nil, tts : Bool = false,
-                       nonce : Int64 | String? = nil)
+                       nonce : Int64 | String? = nil, message_reference : MessageReference? = nil)
       json = encode_tuple(
         content: content,
         embed: embed,
         tts: tts,
-        nonce: nonce
+        nonce: nonce,
+        message_reference: message_reference
       )
 
       response = request(
@@ -324,6 +326,225 @@ module Discord
       )
 
       Message.from_json(response.body)
+    end
+
+    # Start Thread from existing message
+    # When called on a GUILD_TEXT channel, creates a GUILD_PUBLIC_THREAD.
+    # When called on a GUILD_NEWS channel, creates a GUILD_NEWS_THREAD.
+    # The id of the created thread will be the same as the id of the message, and as such a message can only have a single thread created from it.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#start-thread-with-message)
+    def start_thread(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake, name : String, auto_archive_duration : AutoArchiveDuration, reason : String? = nil)
+      json = encode_tuple(
+        name: name,
+        auto_archive_duration: auto_archive_duration
+      )
+
+      headers = HTTP::Headers{
+        "Content-Type" => "application/json",
+      }
+      headers["X-Audit-Log-Reason"] = reason if reason
+
+      response = request(
+        :channels_cid_threads,
+        channel_id,
+        "POST",
+        "/channels/#{channel_id}/messages/#{message_id}/threads",
+        headers,
+        json
+      )
+      pp response
+
+      Channel.from_json(response.body)
+    end
+
+    # Start Thread without Message
+    # Creates a new thread that is not connected to an existing message.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#start-thread-without-message)
+    def start_thread(channel_id : UInt64 | Snowflake, name : String, auto_archive_duration : AutoArchiveDuration, type : ChannelType? = nil, invitable : Bool? = nil, reason : String? = nil)
+      json = encode_tuple(
+        name: name,
+        auto_archive_duration: auto_archive_duration,
+        type: type,
+        invitable: invitable
+      )
+
+      headers = HTTP::Headers{
+        "Content-Type" => "application/json",
+      }
+      headers["X-Audit-Log-Reason"] = reason if reason
+
+      response = request(
+        :channels_cid_threads,
+        channel_id,
+        "POST",
+        "/channels/#{channel_id}/threads",
+        headers,
+        json
+      )
+
+      Channel.from_json(response.body)
+    end
+
+    # Join Thread
+    # Adds the current user to a thread. Also requires the thread is not archived.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#join-thread)
+    def join_thread(channel_id : UInt64 | Snowflake)
+      request(
+        :channels_cid_thread_members,
+        channel_id,
+        "PUT",
+        "/channels/#{channel_id}/thread-members/@me",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    # Add Thread Member
+    # Adds another member to a thread. Requires the ability to send messages in the thread.
+    # Also requires the thread is not archived.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#add-thread-member)
+    def add_thread_member(channel_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake)
+      request(
+        :channels_cid_thread_members,
+        channel_id,
+        "PUT",
+        "/channels/#{channel_id}/thread-members/#{user_id}",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    # Leave Thread
+    # Removes the current user from a thread. Also requires the thread is not archived.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#leave-thread)
+    def leave_thread(channel_id : UInt64 | Snowflake)
+      request(
+        :channels_cid_thread_members,
+        channel_id,
+        "DELETE",
+        "/channels/#{channel_id}/thread-members/@me",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    # Remove Thread Member
+    # Removes another member from a thread. Requires the MANAGE_THREADS permission, or the creator of the thread if it is a GUILD_PRIVATE_THREAD.
+    # Also requires the thread is not archived.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#remove-thread-member)
+    def remove_thread_member(channel_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake)
+      request(
+        :channels_cid_thread_members,
+        channel_id,
+        "DELETE",
+        "/channels/#{channel_id}/thread-members/#{user_id}",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    # List Thread Members
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#list-thread-members)
+    def list_thread_members(channel_id : UInt64 | Snowflake)
+      response = request(
+        :channels_cid_thread_members,
+        channel_id,
+        "GET",
+        "/channels/#{channel_id}/thread-members",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Array(ThreadMember).from_json(response.body)
+    end
+
+    # List Active Threads
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#list-active-threads)
+    def list_active_threads(channel_id : UInt64 | Snowflake)
+      response = request(
+        :channel_cid_threads,
+        channel_id,
+        "GET",
+        "/channels/#{channel_id}/threads/active",
+        HTTP::Headers.new,
+        nil
+      )
+
+      ThreadsPayload.from_json(response.body)
+    end
+
+    # List Public Archived Threads
+    # Returns archived threads in the channel that are public.
+    # When called on a GUILD_TEXT channel, returns threads of type GUILD_PUBLIC_THREAD. When called on a GUILD_NEWS channel returns threads of type GUILD_NEWS_THREAD.
+    # Threads are ordered by archive_timestamp, in descending order. Requires the READ_MESSAGE_HISTORY permission.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#list-public-archived-threads)
+    def list_public_archived_threads(channel_id : UInt64 | Snowflake, before : Time? = nil, limit : Int32? = nil)
+      path = "/channels/#{channel_id}/threads/archived/public"
+      path += "&before=#{before}" if before
+      path += "&limit=#{limit}" if limit
+
+      response = request(
+        :channel_cid_threads,
+        channel_id,
+        "GET",
+        path,
+        HTTP::Headers.new,
+        nil
+      )
+
+      ThreadsPayload.from_json(response.body)
+    end
+
+    # List Private Archived Threads
+    # Returns archived threads in the channel that are of type GUILD_PRIVATE_THREAD.
+    # Threads are ordered by archive_timestamp, in descending order.
+    # Requires both the READ_MESSAGE_HISTORY and MANAGE_THREADS permissions.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#list-private-archived-threads)
+    def list_private_archived_threads(channel_id : UInt64 | Snowflake, before : Time? = nil, limit : Int32? = nil)
+      path = "/channels/#{channel_id}/threads/archived/private"
+      path += "&before=#{before}" if before
+      path += "&limit=#{limit}" if limit
+
+      response = request(
+        :channel_cid_threads,
+        channel_id,
+        "GET",
+        path,
+        HTTP::Headers.new,
+        nil
+      )
+
+      ThreadsPayload.from_json(response.body)
+    end
+
+    # List Joined Private Archived Threads
+    #
+    # [API docs for this method](https://discord.com/developers/docs/resources/channel#list-joined-private-archived-threads)
+    def list_joined_private_threads(channel_id : UInt64 | Snowflake, before : Time? = nil, limit : Int32? = nil)
+      path = "/channels/#{channel_id}/users/@me/threads/archived/private"
+      path += "&before=#{before}" if before
+      path += "&limit=#{limit}" if limit
+
+      response = request(
+        :channel_cid_threads,
+        channel_id,
+        "GET",
+        path,
+        HTTP::Headers.new,
+        nil
+      )
+
+      ThreadsPayload.from_json(response.body)
     end
 
     # Adds a reaction to a message. The `emoji` property must be in the format
@@ -1532,7 +1753,7 @@ module Discord
     end
 
     # Gets embed data for a guild. Requires the "Manage Guild" permission.
-    #
+    # TODO Did this move to /widget?
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#get-guild-embed)
     def get_guild_embed(guild_id : UInt64 | Snowflake)
       response = request(

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -2177,7 +2177,8 @@ module Discord
     def execute_webhook(webhook_id : UInt64 | Snowflake, token : String, content : String? = nil,
                         file : String? = nil, embeds : Array(Embed)? = nil,
                         tts : Bool? = nil, avatar_url : String? = nil,
-                        username : String? = nil, wait : Bool? = false)
+                        username : String? = nil, wait : Bool? = false,
+                        thread_id : UInt64 | Snowflake? = nil)
       json = encode_tuple(
         content: content,
         file: file,
@@ -2187,11 +2188,16 @@ module Discord
         username: username
       )
 
+      params = URI::Params.build do |form|
+        form.add "wait", wait if wait
+        form.add "thread_id", thread_id if thread_id
+      end
+
       response = request(
         :webhooks_wid,
         webhook_id,
         "POST",
-        "/webhooks/#{webhook_id}/#{token}?wait=#{wait}",
+        "/webhooks/#{webhook_id}/#{token}?#{params}",
         HTTP::Headers{"Content-Type" => "application/json"},
         json
       )


### PR DESCRIPTION
This PR scopes moving to API v9, with the main focus on having thread support.
(Some breaking changes such as `/guilds/embed` moving to `/guilds/widget` is tracked in #25 )