### PR TITLE
Allowed Mentions

### DIFF
--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -30,6 +30,22 @@ module Discord
     end
   end
 
+  @[Flags]
+  enum MessageFlags : UInt8
+    Crossposted          = 1 << 0
+    IsCrosspost          = 1 << 1
+    SuppressEmbeds       = 1 << 2
+    SourceMessageDeleted = 1 << 3
+    Urgent               = 1 << 4
+    HasThread            = 1 << 5
+    Ephemeral            = 1 << 6
+    Loading              = 1 << 7
+
+    def self.new(pull : JSON::PullParser)
+      MessageFlags.new(pull.read_int.to_u8)
+    end
+  end
+
   enum AutoArchiveDuration : UInt16
     Hour      =    60
     Day       =  1440
@@ -57,17 +73,22 @@ module Discord
     property member : PartialGuildMember?
     @[JSON::Field(converter: Discord::TimestampConverter)]
     property timestamp : Time
+    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+    property edited_timestamp : Time?
     property tts : Bool
     property mention_everyone : Bool
     property mentions : Array(User)
     property mention_roles : Array(Snowflake)
+    property mention_channels : Array(Snowflake)?
     property attachments : Array(Attachment)
     property embeds : Array(Embed)
     property pinned : Bool?
     property reactions : Array(Reaction)?
     property nonce : String | Int64?
     property activity : Activity?
+    property application : OAuth2Application?
     property webhook_id : Snowflake?
+    property flags : MessageFlags?
     property thread : Channel?
     property referenced_message : Message?
 
@@ -142,6 +163,11 @@ module Discord
     end
   end
 
+  enum VideoQualityMode : UInt8
+    Auto = 1
+    Full = 2
+  end
+
   struct Channel
     include JSON::Serializable
 
@@ -162,6 +188,10 @@ module Discord
     property position : Int32?
     property parent_id : Snowflake?
     property rate_limit_per_user : Int32?
+    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+    property last_pin_timestamp : Time?
+    property rtc_region : VoiceRegion?
+    property video_quality_mode : VideoQualityMode?
     property thread_metadata : ThreadMetaData?
     property message_count : UInt32?
     property member_count : UInt32?

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -89,6 +89,19 @@ module Discord
     end
   end
 
+  struct AllowedMentions
+    include JSON::Serializable
+
+    property parse : Array(String)?
+    property roles : Array(Snowflake)?
+    property users : Array(Snowflake)?
+    property replied_user : Bool
+
+    def initialize(@parse : Array(String)? = nil, @roles : Array(Snowflake)? = nil,
+                   @users : Array(Snowflake)? = nil, @replied_user : Bool = false)
+    end
+  end
+
   enum ActivityType : UInt8
     Join        = 1
     Spectate    = 2

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -312,12 +312,13 @@ module Discord
     # For more details on the format of the `embed` object, look at the
     # [relevant documentation](https://discord.com/developers/docs/resources/channel#embed-object).
     def create_message(channel_id : UInt64 | Snowflake, content : String, embed : Embed? = nil, tts : Bool = false,
-                       nonce : Int64 | String? = nil, message_reference : MessageReference? = nil)
+                       nonce : Int64 | String? = nil, allowed_mentions : AllowedMentions? = nil, message_reference : MessageReference? = nil)
       json = encode_tuple(
         content: content,
         embed: embed,
         tts: tts,
         nonce: nonce,
+        allowed_mentions: allowed_mentions,
         message_reference: message_reference
       )
 
@@ -660,7 +661,7 @@ module Discord
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#create-message)
     # (same as `#create_message` -- this method implements form data bodies
     # while `#create_message` implements JSON bodies)
-    def upload_file(channel_id : UInt64 | Snowflake, content : String?, file : IO, filename : String? = nil, embed : Embed? = nil, spoiler : Bool = false)
+    def upload_file(channel_id : UInt64 | Snowflake, content : String?, file : IO, filename : String? = nil, embed : Embed? = nil, allowed_mentions : AllowedMentions? = nil, spoiler : Bool = false)
       io = IO::Memory.new
 
       unless filename
@@ -680,7 +681,8 @@ module Discord
       if content || embed
         json = encode_tuple(
           content: content,
-          embed: embed
+          embed: embed,
+          allowed_mentions: allowed_mentions
         )
         builder.field("payload_json", json)
       end
@@ -2178,15 +2180,16 @@ module Discord
     def execute_webhook(webhook_id : UInt64 | Snowflake, token : String, content : String? = nil,
                         file : String? = nil, embeds : Array(Embed)? = nil,
                         tts : Bool? = nil, avatar_url : String? = nil,
-                        username : String? = nil, wait : Bool? = false,
-                        thread_id : UInt64 | Snowflake? = nil)
+                        username : String? = nil, allowed_mentions : AllowedMentions? = nil,
+                        wait : Bool? = false, thread_id : UInt64 | Snowflake? = nil)
       json = encode_tuple(
         content: content,
         file: file,
         embeds: embeds,
         tts: tts,
         avatar_url: avatar_url,
-        username: username
+        username: username,
+        allowed_mentions: allowed_mentions
       )
 
       params = URI::Params.build do |form|

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -661,7 +661,8 @@ module Discord
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#create-message)
     # (same as `#create_message` -- this method implements form data bodies
     # while `#create_message` implements JSON bodies)
-    def upload_file(channel_id : UInt64 | Snowflake, content : String?, file : IO, filename : String? = nil, embed : Embed? = nil, allowed_mentions : AllowedMentions? = nil, spoiler : Bool = false)
+    def upload_file(channel_id : UInt64 | Snowflake, content : String?, file : IO, filename : String? = nil,
+                    embed : Embed? = nil, allowed_mentions : AllowedMentions? = nil, spoiler : Bool = false)
       io = IO::Memory.new
 
       unless filename


### PR DESCRIPTION
While the main purpose is to add support for allowed mentions (it's straightforward), this PR also includes some missing fields in `Channel` and `Message`.
I suppose `application` field in `Message` is referring to what discordcr has in `OAuth2Application`, but I feel the name doesn't match the current state anymore. (including `REST#get_oauth2_application`, now it just says "Get Current Bot Application Information" in the doc)