### PR TITLE
Slash Commands, Message Components, and Interactions

### DIFF
--- a/examples/interactions.cr
+++ b/examples/interactions.cr
@@ -55,18 +55,18 @@ commands.push(
 client.bulk_overwrite_global_application_commands(commands)
 
 # Handle interactions
-client.on_interaction_create do |interaction|  
+client.on_interaction_create do |interaction|
   if interaction.type.application_command?
-    data = interaction.application_command_data
+    data = interaction.data.as(Discord::ApplicationCommandInteractionData)
 
-    case data[:name]
+    case data.name
     when "animal"
       response = Discord::InteractionResponse.message(
-        data[:options].not_nil!.first.value.to_s
+        data.options.not_nil!.first.value.to_s
       )
       client.create_interaction_response(interaction.id, interaction.token, response)
     when "counter"
-      step = data[:options].try(&.first.value) || 1
+      step = data.options.try(&.first.value) || 1
       response = Discord::InteractionResponse.message(
         "0",
         components: [
@@ -79,9 +79,9 @@ client.on_interaction_create do |interaction|
       client.create_interaction_response(interaction.id, interaction.token, response)
     end
   elsif interaction.type.message_component?
-    data = interaction.message_component_data
+    data = interaction.data.as(Discord::MessageComponentInteractionData)
 
-    key, value = data[:custom_id].split(":")
+    key, value = data.custom_id.split(":")
     count = interaction.message.not_nil!.content.to_i
     case key
     when "add"

--- a/examples/interactions.cr
+++ b/examples/interactions.cr
@@ -1,0 +1,100 @@
+# This example bot demonstrates interaction-related features
+# such as Application Commands and Message Components.
+#
+# For more information on interactions in general, see
+# https://discord.com/developers/docs/interactions/receiving-and-responding#interactions-and-bot-users
+
+require "../src/discordcr"
+
+# Make sure to replace this fake data with actual data when running.
+client = Discord::Client.new(token: "Bot MjI5NDU5NjgxOTU1NjUyMzM3.Cpnz31.GQ7K9xwZtvC40y8MPY3eTqjEIXm", client_id: 229459681955652337_u64)
+
+# Making an array of commands with `PartialApplicationCommand`
+# to register multiple commands altogether.
+# You may want to separate these procedures into a separate program to avoid
+# registering the same many commands each time you start the bot.
+
+commands = [] of Discord::PartialApplicationCommand
+
+commands.push(
+  Discord::PartialApplicationCommand.new(
+    name: "animal",
+    description: "Reacts with the type of animal you select",
+    options: [
+      Discord::ApplicationCommandOption.string(
+        name: "animal_type",
+        description: "The type of animal you want to hear from",
+        required: true,
+        choices: [
+          Discord::ApplicationCommandOptionChoice.new(
+            "dog", "woof!"
+          ),
+          Discord::ApplicationCommandOptionChoice.new(
+            "cat", "meow"
+          )
+        ]
+      )
+    ]
+  )
+)
+
+commands.push(
+  Discord::PartialApplicationCommand.new(
+    name: "counter",
+    description: "Show a step-up/step-down counter",
+    options: [
+      Discord::ApplicationCommandOption.integer(
+        name: "step",
+        description: "Increase/decrease per step (Default: 1)"
+      )
+    ]
+  )
+)
+
+# You can also register one by one with `#create_global_application_command`
+client.bulk_overwrite_global_application_commands(commands)
+
+# Handle interactions
+client.on_interaction_create do |interaction|  
+  if interaction.type.application_command?
+    data = interaction.application_command_data
+
+    case data[:name]
+    when "animal"
+      response = Discord::InteractionResponse.message(
+        data[:options].not_nil!.first.value.to_s
+      )
+      client.create_interaction_response(interaction.id, interaction.token, response)
+    when "counter"
+      step = data[:options].try(&.first.value) || 1
+      response = Discord::InteractionResponse.message(
+        "0",
+        components: [
+          Discord::ActionRow.new(
+            Discord::Button.new(Discord::ButtonStyle::Primary, "-", custom_id: "sub:#{step}"),
+            Discord::Button.new(Discord::ButtonStyle::Primary, "+", custom_id: "add:#{step}")
+          )
+        ]
+      )
+      client.create_interaction_response(interaction.id, interaction.token, response)
+    end
+  elsif interaction.type.message_component?
+    data = interaction.message_component_data
+
+    key, value = data[:custom_id].split(":")
+    count = interaction.message.not_nil!.content.to_i
+    case key
+    when "add"
+      count += value.to_i
+    when "sub"
+      count -= value.to_i
+    end
+
+    response = Discord::InteractionResponse.update_message(
+      count.to_s
+    )
+    client.create_interaction_response(interaction.id, interaction.token, response)
+  end
+end
+
+client.run

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -592,6 +592,10 @@ module Discord
         @cache.try &.remove_guild_role(payload.guild_id, payload.role_id)
 
         call_event guild_role_delete, payload
+      when "INTERACTION_CREATE"
+        payload = Interaction.from_json(data)
+
+        call_event interaction_create, payload
       when "INVITE_CREATE"
         payload = Gateway::InviteCreatePayload.from_json(data)
 
@@ -894,6 +898,11 @@ module Discord
     #
     # [API docs for this event](https://discord.com/developers/docs/topics/gateway#guild-role-delete)
     event guild_role_delete, Gateway::GuildRoleDeletePayload
+
+    # Called when a user in a guild uses an Application Command.
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#interaction-create)
+    event interaction_create, Interaction
 
     # Called when an invite is created on a guild.
     #

--- a/src/discordcr/mappings/application_commands.cr
+++ b/src/discordcr/mappings/application_commands.cr
@@ -1,0 +1,172 @@
+require "./converters"
+
+module Discord
+  enum ApplicationCommandType : UInt8
+    ChatInput = 1
+    User      = 2
+    Message   = 3
+
+    def to_json(json : JSON::Builder)
+      json.number(value)
+    end
+  end
+
+  struct ApplicationCommand
+    include JSON::Serializable
+
+    property id : Snowflake
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::ApplicationCommandType))]
+    property type : ApplicationCommandType?
+    property application_id : Snowflake
+    property guild_id : Snowflake?
+    property name : String
+    property description : String
+    property options : Array(ApplicationCommandOption)?
+    property default_permission : Bool?
+    property version : Snowflake
+  end
+
+  # `ApplicationCommand` object used for bulk overwriting commands
+  struct PartialApplicationCommand
+    include JSON::Serializable
+
+    property name : String
+    property description : String
+    property options : Array(ApplicationCommandOption)?
+    property default_permission : Bool?
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::ApplicationCommandType))]
+    property type : ApplicationCommandType?
+
+    def initialize(@name, @description = "", @options = nil, @default_permission = nil, @type = nil)
+    end
+  end
+
+  enum ApplicationCommandOptionType : UInt8
+    SubCommand      =  1
+    SubCommandGroup =  2
+    String          =  3
+    Integer         =  4
+    Boolean         =  5
+    User            =  6
+    Channel         =  7
+    Role            =  8
+    Mentionable     =  9
+    Number          = 10
+  end
+
+  struct ApplicationCommandOption
+    include JSON::Serializable
+
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::ApplicationCommandOptionType))]
+    property type : ApplicationCommandOptionType
+    property name : String
+    property description : String
+    property required : Bool?
+    property choices : Array(ApplicationCommandOptionChoice)?
+    property options : Array(ApplicationCommandOption)?
+
+    def initialize(@type, @name, @description, @required = nil, @choices = nil, @options = nil)
+    end
+
+    def self.sub_command(name : String, description : String, required : Bool? = nil,
+                         options : Array(ApplicationCommandOption)? = nil)
+      self.new(ApplicationCommandOptionType::SubCommand, name, description, required, nil, options)
+    end
+
+    def self.sub_command_group(name : String, description : String, required : Bool? = nil,
+                               options : Array(ApplicationCommandOption)? = nil)
+      self.new(ApplicationCommandOptionType::SubCommandGroup, name, description, required, nil, options)
+    end
+
+    def self.string(name : String, description : String, required : Bool? = nil,
+                    choices : Array(ApplicationCommandOptionChoice)? = nil)
+      self.new(ApplicationCommandOptionType::String, name, description, required, choices, nil)
+    end
+
+    def self.integer(name : String, description : String, required : Bool? = nil,
+                     choices : Array(ApplicationCommandOptionChoice)? = nil)
+      self.new(ApplicationCommandOptionType::Integer, name, description, required, choices, nil)
+    end
+
+    def self.boolean(name : String, description : String, required : Bool? = nil)
+      self.new(ApplicationCommandOptionType::Boolean, name, description, required, nil, nil)
+    end
+
+    def self.user(name : String, description : String, required : Bool? = nil)
+      self.new(ApplicationCommandOptionType::User, name, description, required, nil, nil)
+    end
+
+    def self.channel(name : String, description : String, required : Bool? = nil)
+      self.new(ApplicationCommandOptionType::Channel, name, description, required, nil, nil)
+    end
+
+    def self.role(name : String, description : String, required : Bool? = nil)
+      self.new(ApplicationCommandOptionType::Role, name, description, required, nil, nil)
+    end
+
+    def self.mentionalble(name : String, description : String, required : Bool? = nil)
+      self.new(ApplicationCommandOptionType::Mentionable, name, description, required, nil, nil)
+    end
+
+    def self.number(name : String, description : String, required : Bool? = nil,
+                    choices : Array(ApplicationCommandOptionChoice)? = nil)
+      self.new(ApplicationCommandOptionType::Number, name, description, required, choices, nil)
+    end
+  end
+
+  struct ApplicationCommandOptionChoice
+    include JSON::Serializable
+
+    property name : String
+    property value : String | Int32 | Int64 | Float32 | Float64
+
+    def initialize(@name, @value)
+    end
+  end
+
+  struct ApplicationCommandInteractionDataOption
+    include JSON::Serializable
+
+    property name : String
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::ApplicationCommandOptionType))]
+    property type : ApplicationCommandOptionType
+    property value : String | Int32 | Int64 | Float32 | Float64 | Bool | Snowflake?
+    property options : Array(ApplicationCommandInteractionDataOption)?
+  end
+
+  struct GuildApplicationCommandPermissions
+    include JSON::Serializable
+
+    property id : Snowflake
+    property application_id : Snowflake
+    property guild_id : Snowflake
+    property permissions : Array(ApplicationCommandPermissions)
+  end
+
+  enum ApplicationCommandPermissionType : UInt8
+    Role = 1
+    User = 2
+  end
+
+  struct ApplicationCommandPermissions
+    include JSON::Serializable
+
+    property id : Snowflake
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::ApplicationCommandPermissionType))]
+    property type : ApplicationCommandPermissionType
+    property permission : Bool
+
+    def initialize(@id, @type, @permission)
+    end
+
+    def self.role(id : UInt64 | Snowflake, permissions : Bool)
+      id = Snowflake.new(id) unless id.is_a?(Snowflake)
+      self.new(id, ApplicationCommandPermissionType::Role, permissions)
+    end
+
+    def self.user(id : UInt64 | Snowflake, permissions : Bool)
+      id = Snowflake.new(id) unless id.is_a?(Snowflake)
+      self.new(id, ApplicationCommandPermissionType::User, permissions)
+    end
+  end
+end

--- a/src/discordcr/mappings/application_commands.cr
+++ b/src/discordcr/mappings/application_commands.cr
@@ -64,53 +64,54 @@ module Discord
     property required : Bool?
     property choices : Array(ApplicationCommandOptionChoice)?
     property options : Array(ApplicationCommandOption)?
+    property channel_types : Array(ChannelType)?
 
-    def initialize(@type, @name, @description, @required = nil, @choices = nil, @options = nil)
+    def initialize(@type, @name, @description, @required = nil, @choices = nil, @options = nil, @channel_types = nil)
     end
 
     def self.sub_command(name : String, description : String, required : Bool? = nil,
                          options : Array(ApplicationCommandOption)? = nil)
-      self.new(ApplicationCommandOptionType::SubCommand, name, description, required, nil, options)
+      self.new(ApplicationCommandOptionType::SubCommand, name, description, required, nil, options, nil)
     end
 
     def self.sub_command_group(name : String, description : String, required : Bool? = nil,
                                options : Array(ApplicationCommandOption)? = nil)
-      self.new(ApplicationCommandOptionType::SubCommandGroup, name, description, required, nil, options)
+      self.new(ApplicationCommandOptionType::SubCommandGroup, name, description, required, nil, options, nil)
     end
 
     def self.string(name : String, description : String, required : Bool? = nil,
                     choices : Array(ApplicationCommandOptionChoice)? = nil)
-      self.new(ApplicationCommandOptionType::String, name, description, required, choices, nil)
+      self.new(ApplicationCommandOptionType::String, name, description, required, choices, nil, nil)
     end
 
     def self.integer(name : String, description : String, required : Bool? = nil,
                      choices : Array(ApplicationCommandOptionChoice)? = nil)
-      self.new(ApplicationCommandOptionType::Integer, name, description, required, choices, nil)
+      self.new(ApplicationCommandOptionType::Integer, name, description, required, choices, nil, nil)
     end
 
     def self.boolean(name : String, description : String, required : Bool? = nil)
-      self.new(ApplicationCommandOptionType::Boolean, name, description, required, nil, nil)
+      self.new(ApplicationCommandOptionType::Boolean, name, description, required, nil, nil, nil)
     end
 
     def self.user(name : String, description : String, required : Bool? = nil)
-      self.new(ApplicationCommandOptionType::User, name, description, required, nil, nil)
+      self.new(ApplicationCommandOptionType::User, name, description, required, nil, nil, nil)
     end
 
-    def self.channel(name : String, description : String, required : Bool? = nil)
-      self.new(ApplicationCommandOptionType::Channel, name, description, required, nil, nil)
+    def self.channel(name : String, description : String, required : Bool? = nil, channel_types : Array(ChannelType)? = nil)
+      self.new(ApplicationCommandOptionType::Channel, name, description, required, nil, nil, channel_types)
     end
 
     def self.role(name : String, description : String, required : Bool? = nil)
-      self.new(ApplicationCommandOptionType::Role, name, description, required, nil, nil)
+      self.new(ApplicationCommandOptionType::Role, name, description, required, nil, nil, nil)
     end
 
     def self.mentionalble(name : String, description : String, required : Bool? = nil)
-      self.new(ApplicationCommandOptionType::Mentionable, name, description, required, nil, nil)
+      self.new(ApplicationCommandOptionType::Mentionable, name, description, required, nil, nil, nil)
     end
 
     def self.number(name : String, description : String, required : Bool? = nil,
                     choices : Array(ApplicationCommandOptionChoice)? = nil)
-      self.new(ApplicationCommandOptionType::Number, name, description, required, choices, nil)
+      self.new(ApplicationCommandOptionType::Number, name, description, required, choices, nil, nil)
     end
   end
 

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -92,7 +92,7 @@ module Discord
     property flags : MessageFlags?
     property thread : Channel?
     property referenced_message : Message?
-    property interaction : Interaction?
+    property interaction : MessageInteraction?
     property components : Array(Component)?
 
     def message_reference : MessageReference

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -87,10 +87,13 @@ module Discord
     property nonce : String | Int64?
     property activity : Activity?
     property application : OAuth2Application?
+    property application_id : Snowflake?
     property webhook_id : Snowflake?
     property flags : MessageFlags?
     property thread : Channel?
     property referenced_message : Message?
+    property interaction : Interaction?
+    property components : Array(Component)?
 
     def message_reference : MessageReference
       MessageReference.new(@id, @channel_id, @guild_id)
@@ -198,6 +201,7 @@ module Discord
     property member : ThreadMember?
     property default_auto_archive_duration : AutoArchiveDuration?
     property last_message_id : Snowflake?
+    property permissions : String?
 
     # :nodoc:
     def initialize(private_channel : PrivateChannel)

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -30,6 +30,22 @@ module Discord
     end
   end
 
+  @[Flags]
+  enum MessageFlags : UInt8
+    Crossposted          = 1 << 0
+    IsCrosspost          = 1 << 1
+    SuppressEmbeds       = 1 << 2
+    SourceMessageDeleted = 1 << 3
+    Urgent               = 1 << 4
+    HasThread            = 1 << 5
+    Ephemeral            = 1 << 6
+    Loading              = 1 << 7
+
+    def self.new(pull : JSON::PullParser)
+      MessageFlags.new(pull.read_int.to_u8)
+    end
+  end
+
   enum AutoArchiveDuration : UInt16
     Hour      =    60
     Day       =  1440
@@ -57,17 +73,22 @@ module Discord
     property member : PartialGuildMember?
     @[JSON::Field(converter: Discord::TimestampConverter)]
     property timestamp : Time
+    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+    property edited_timestamp : Time?
     property tts : Bool
     property mention_everyone : Bool
     property mentions : Array(User)
     property mention_roles : Array(Snowflake)
+    property mention_channels : Array(Snowflake)?
     property attachments : Array(Attachment)
     property embeds : Array(Embed)
     property pinned : Bool?
     property reactions : Array(Reaction)?
     property nonce : String | Int64?
     property activity : Activity?
+    property application : OAuth2Application?
     property webhook_id : Snowflake?
+    property flags : MessageFlags?
     property thread : Channel?
     property referenced_message : Message?
 
@@ -142,6 +163,11 @@ module Discord
     end
   end
 
+  enum VideoQualityMode : UInt8
+    Auto = 1
+    Full = 2
+  end
+
   struct Channel
     include JSON::Serializable
 
@@ -162,6 +188,10 @@ module Discord
     property position : Int32?
     property parent_id : Snowflake?
     property rate_limit_per_user : Int32?
+    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+    property last_pin_timestamp : Time?
+    property rtc_region : VoiceRegion?
+    property video_quality_mode : VideoQualityMode?
     property thread_metadata : ThreadMetaData?
     property message_count : UInt32?
     property member_count : UInt32?

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -89,6 +89,19 @@ module Discord
     end
   end
 
+  struct AllowedMentions
+    include JSON::Serializable
+
+    property parse : Array(String)?
+    property roles : Array(Snowflake)?
+    property users : Array(Snowflake)?
+    property replied_user : Bool
+
+    def initialize(@parse : Array(String)? = nil, @roles : Array(Snowflake)? = nil,
+                   @users : Array(Snowflake)? = nil, @replied_user : Bool = false)
+    end
+  end
+
   enum ActivityType : UInt8
     Join        = 1
     Spectate    = 2

--- a/src/discordcr/mappings/components.cr
+++ b/src/discordcr/mappings/components.cr
@@ -1,0 +1,82 @@
+require "./converters"
+
+module Discord
+  enum ComponentType : UInt8
+    ActionRow  = 1
+    Button     = 2
+    SelectMenu = 3
+  end
+
+  enum ButtonStyle : UInt8
+    Primary = 1
+    Secondary = 2
+    Success = 3
+    Danger = 4
+    Link = 5
+  end
+
+  abstract struct Component
+    include JSON::Serializable
+
+    use_json_discriminator "type", {
+      ComponentType::ActionRow => ActionRow,
+      ComponentType::Button => Button,
+      ComponentType::SelectMenu => SelectMenu
+    }
+
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::ComponentType))]
+    property type : ComponentType
+  end
+
+  struct ActionRow < Component
+    @type : ComponentType = ComponentType::ActionRow
+
+    property components : Array(Button | SelectMenu)
+
+    def initialize(*components : Button | SelectMenu)
+      @components = [*components] of Button | SelectMenu
+    end
+  end
+
+  struct Button < Component
+    @type : ComponentType = ComponentType::Button
+
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::ButtonStyle))]
+    property style : ButtonStyle
+    property label : String?
+    property emoji : Emoji?
+    property custom_id : String?
+    property url : String?
+    property disabled : Bool?
+
+    def initialize(@style, @label = nil, @emoji = nil, @custom_id = nil, @url = nil, @disabled = nil)
+    end
+  end
+
+  struct SelectMenu < Component
+    @type : ComponentType = ComponentType::SelectMenu
+
+    property custom_id : String?
+    property options : Array(SelectOption)
+    property placeholder : String?
+    property min_values : UInt8?
+    property max_values : UInt8?
+    property disabled : Bool?
+
+    def initialize(@options, @custom_id = nil, @placeholder = nil, @min_values = nil, @max_values = nil, @disabled = nil)
+    end
+  end
+
+  struct SelectOption
+    include JSON::Serializable
+
+    property label : String
+    property value : String
+    property description : String?
+    property emoji : Emoji?
+    property default : Bool?
+
+    def initialize(@label, @value, @description = nil, @emoji = nil, @default = nil)
+    end
+  end
+end

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -156,8 +156,8 @@ module Discord
     property joined_at : Time
     @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
     property premium_since : Time?
-    property deaf : Bool
-    property mute : Bool
+    property deaf : Bool?
+    property mute : Bool?
   end
 
   struct Integration

--- a/src/discordcr/mappings/interactions.cr
+++ b/src/discordcr/mappings/interactions.cr
@@ -71,7 +71,7 @@ module Discord
     include JSON::Serializable
 
     property users : Hash(Snowflake, User)?
-    property members : Hash(Snowflake, GuildMember)?
+    property members : Hash(Snowflake, PartialGuildMember)?
     property roles : Hash(Snowflake, Role)?
     property channels : Hash(Snowflake, Channel)?
     property messages : Hash(Snowflake, Message)?

--- a/src/discordcr/mappings/interactions.cr
+++ b/src/discordcr/mappings/interactions.cr
@@ -74,6 +74,17 @@ module Discord
     property members : Hash(Snowflake, GuildMember)?
     property roles : Hash(Snowflake, Role)?
     property channels : Hash(Snowflake, Channel)?
+    property messages : Hash(Snowflake, Message)?
+  end
+
+  struct MessageInteraction
+    include JSON::Serializable
+
+    property id : Snowflake
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::InteractionType))]
+    property type : InteractionType
+    property name : String
+    property user : User
   end
 
   enum InteractionCallbackType : UInt8

--- a/src/discordcr/mappings/interactions.cr
+++ b/src/discordcr/mappings/interactions.cr
@@ -144,7 +144,7 @@ module Discord
     property tts : Bool?
     property content : String?
     property embeds : Array(Embed)?
-    # property allowed_mentions : AllowedMentions?
+    property allowed_mentions : AllowedMentions?
     @[JSON::Field(converter: Enum::ValueConverter(Discord::InteractionCallbackDataFlags))]
     property flags : InteractionCallbackDataFlags?
     property components : Array(ActionRow)?

--- a/src/discordcr/mappings/interactions.cr
+++ b/src/discordcr/mappings/interactions.cr
@@ -1,0 +1,155 @@
+require "./converters"
+
+module Discord
+  enum InteractionType : UInt8
+    Ping               = 1
+    ApplicationCommand = 2
+    MessageComponent   = 3
+  end
+
+  struct Interaction
+    include JSON::Serializable
+
+    property id : Snowflake
+    property application_id : Snowflake
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::InteractionType))]
+    property type : InteractionType
+    property data : InteractionData?
+    property guild_id : Snowflake?
+    property channel_id : Snowflake?
+    property member : GuildMember?
+    property user : User?
+    property token : String
+    property version : Int32
+    property message : Message?
+
+    # Returns the interaction data within `#data` variable associated with `InteractionType::ApplicationCommand` interaction type, and unwraps nilable variables if possible.
+    #
+    # Since `InteractionData` is used for different interaction types with different choice of fields, all its variables are nilable by default, but we can ensure some non-nil variables if we know the type of the interaction.
+    def application_command_data
+      data = @data.not_nil! # data is always present for this interaction type
+      {
+        id: data.id.not_nil!,
+        name: data.name.not_nil!,
+        type: data.type.not_nil!,
+        resolved: data.resolved,
+        options: data.options,
+        target_id: data.target_id
+      }
+    end
+
+    # Returns the interaction data within `#data` variable associated with `InteractionType::MessageComponent` interaction type, and unwraps nilable variables if possible.
+    #
+    # Since `InteractionData` is used for different interaction types with different choice of fields, all its variables are nilable by default, but we can ensure some non-nil variables if we know the type of the interaction.
+    def message_component_data
+      data = @data.not_nil! # data is always present for this interaction type
+      {
+        custom_id: data.custom_id.not_nil!,
+        component_type: data.component_type.not_nil!,
+        values: data.values
+      }
+    end
+  end
+
+  struct InteractionData
+    include JSON::Serializable
+
+    property id : Snowflake?
+    property name : String?
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::ApplicationCommandType))]
+    property type : ApplicationCommandType?
+    property resolved : ResolvedInteractionData?
+    property options : Array(ApplicationCommandInteractionDataOption)?
+    property custom_id : String?
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::ComponentType))]
+    property component_type : ComponentType?
+    property values : Array(String)?
+    property target_id : Snowflake?
+  end
+
+  struct ResolvedInteractionData
+    include JSON::Serializable
+
+    property users : Hash(Snowflake, User)?
+    property members : Hash(Snowflake, GuildMember)?
+    property roles : Hash(Snowflake, Role)?
+    property channels : Hash(Snowflake, Channel)?
+  end
+
+  enum InteractionCallbackType : UInt8
+    Pong                             = 1
+    ChannelMessageWithSource         = 4
+    DeferredChannelMessageWithSource = 5
+    DeferredUpdateMessage            = 6
+    UpdateMessage                    = 7
+  end
+
+  struct InteractionResponse
+    include JSON::Serializable
+
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::InteractionCallbackType))]
+    property type : InteractionCallbackType
+    property data : InteractionCallbackData
+
+    def initialize(@type, @data = nil)
+    end
+
+    def self.pong
+      self.new(InteractionCallbackType::Pong)
+    end
+
+    def self.message(data : InteractionCallbackData)
+      self.new(InteractionCallbackType::ChannelMessageWithSource, data)
+    end
+
+    def self.message(content : String? = nil, embeds : Array(Embed)? = nil,
+                     components : Array(ActionRow)? = nil,
+                     flags : InteractionCallbackDataFlags? = nil, tts : Bool? = nil)
+      data = InteractionCallbackData.new(content, embeds, components, flags, tts)
+      self.message(data)
+    end
+
+    def self.deferred_message
+      self.new(InteractionCallbackType::DeferredChannelMessageWithSource)
+    end
+
+    def self.deferred_update_message
+      self.new(InteractionCallbackType::DeferredUpdateMessage)
+    end
+
+    def self.update_message(data : InteractionCallbackData)
+      self.new(InteractionCallbackType::UpdateMessage, data)
+    end
+
+    def self.update_message(content : String? = nil, embeds : Array(Embed)? = nil,
+                            components : Array(ActionRow)? = nil,
+                            flags : InteractionCallbackDataFlags? = nil, tts : Bool? = nil)
+      data = InteractionCallbackData.new(content, embeds, components, flags, tts)
+      self.update_message(data)
+    end
+  end
+
+  @[Flags]
+  enum InteractionCallbackDataFlags
+    Ephemeral = 1 << 6
+
+    def to_json(json : JSON::Builder)
+      json.number(value)
+    end
+  end
+
+  struct InteractionCallbackData
+    include JSON::Serializable
+
+    property tts : Bool?
+    property content : String?
+    property embeds : Array(Embed)?
+    # property allowed_mentions : AllowedMentions?
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::InteractionCallbackDataFlags))]
+    property flags : InteractionCallbackDataFlags?
+    property components : Array(ActionRow)?
+
+    def initialize(@content = nil, @embeds = nil, @components = nil, @flags = nil, @tts = nil)
+    end
+  end
+end

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -312,12 +312,13 @@ module Discord
     # For more details on the format of the `embed` object, look at the
     # [relevant documentation](https://discord.com/developers/docs/resources/channel#embed-object).
     def create_message(channel_id : UInt64 | Snowflake, content : String, embed : Embed? = nil, tts : Bool = false,
-                       nonce : Int64 | String? = nil, message_reference : MessageReference? = nil)
+                       nonce : Int64 | String? = nil, allowed_mentions : AllowedMentions? = nil, message_reference : MessageReference? = nil)
       json = encode_tuple(
         content: content,
         embed: embed,
         tts: tts,
         nonce: nonce,
+        allowed_mentions: allowed_mentions,
         message_reference: message_reference
       )
 
@@ -660,7 +661,7 @@ module Discord
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#create-message)
     # (same as `#create_message` -- this method implements form data bodies
     # while `#create_message` implements JSON bodies)
-    def upload_file(channel_id : UInt64 | Snowflake, content : String?, file : IO, filename : String? = nil, embed : Embed? = nil, spoiler : Bool = false)
+    def upload_file(channel_id : UInt64 | Snowflake, content : String?, file : IO, filename : String? = nil, embed : Embed? = nil, allowed_mentions : AllowedMentions? = nil, spoiler : Bool = false)
       io = IO::Memory.new
 
       unless filename
@@ -680,7 +681,8 @@ module Discord
       if content || embed
         json = encode_tuple(
           content: content,
-          embed: embed
+          embed: embed,
+          allowed_mentions: allowed_mentions
         )
         builder.field("payload_json", json)
       end
@@ -2178,15 +2180,16 @@ module Discord
     def execute_webhook(webhook_id : UInt64 | Snowflake, token : String, content : String? = nil,
                         file : String? = nil, embeds : Array(Embed)? = nil,
                         tts : Bool? = nil, avatar_url : String? = nil,
-                        username : String? = nil, wait : Bool? = false,
-                        thread_id : UInt64 | Snowflake? = nil)
+                        username : String? = nil, allowed_mentions : AllowedMentions? = nil,
+                        wait : Bool? = false, thread_id : UInt64 | Snowflake? = nil)
       json = encode_tuple(
         content: content,
         file: file,
         embeds: embeds,
         tts: tts,
         avatar_url: avatar_url,
-        username: username
+        username: username,
+        allowed_mentions: allowed_mentions
       )
 
       params = URI::Params.build do |form|

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -312,14 +312,16 @@ module Discord
     # For more details on the format of the `embed` object, look at the
     # [relevant documentation](https://discord.com/developers/docs/resources/channel#embed-object).
     def create_message(channel_id : UInt64 | Snowflake, content : String, embed : Embed? = nil, tts : Bool = false,
-                       nonce : Int64 | String? = nil, allowed_mentions : AllowedMentions? = nil, message_reference : MessageReference? = nil)
+                       nonce : Int64 | String? = nil, allowed_mentions : AllowedMentions? = nil,
+                       message_reference : MessageReference? = nil, components : Array(Component)? = nil)
       json = encode_tuple(
         content: content,
         embed: embed,
         tts: tts,
         nonce: nonce,
         allowed_mentions: allowed_mentions,
-        message_reference: message_reference
+        message_reference: message_reference,
+        components: components
       )
 
       response = request(

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -661,7 +661,8 @@ module Discord
     # [API docs for this method](https://discord.com/developers/docs/resources/channel#create-message)
     # (same as `#create_message` -- this method implements form data bodies
     # while `#create_message` implements JSON bodies)
-    def upload_file(channel_id : UInt64 | Snowflake, content : String?, file : IO, filename : String? = nil, embed : Embed? = nil, allowed_mentions : AllowedMentions? = nil, spoiler : Bool = false)
+    def upload_file(channel_id : UInt64 | Snowflake, content : String?, file : IO, filename : String? = nil,
+                    embed : Embed? = nil, allowed_mentions : AllowedMentions? = nil, spoiler : Bool = false)
       io = IO::Memory.new
 
       unless filename

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -2210,5 +2210,510 @@ module Discord
       # Expecting response
       Message.from_json(response.body) if wait
     end
+
+    # Fetch all of the global commands for your application.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands)
+    def get_global_application_commands
+      application_id = client_id
+
+      response = request(
+        :applications_aid_commands,
+        application_id,
+        "GET",
+        "/applications/#{application_id}/commands",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Array(ApplicationCommand).from_json(response.body)
+    end
+
+    # Create a new global command. New global commands will be available in all guilds after 1 hour.
+    #
+    # NOTE: Creating a command with the same name as an existing command for your application will overwrite the old command.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/application-commands#create-global-application-command)
+    def create_global_application_command(name : String, description : String, 
+                                          options : Array(ApplicationCommandOption)? = nil, 
+                                          default_permission : Bool? = nil,
+                                          type : ApplicationCommandType? = ApplicationCommandType::ChatInput)
+      application_id = client_id
+      
+      json = encode_tuple(
+        name: name,
+        description: description,
+        options: options,
+        default_permission: default_permission,
+        type: type
+      )
+
+      response = request(
+        :applications_aid_commands,
+        application_id,
+        "POST",
+        "/applications/#{application_id}/commands",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+
+      ApplicationCommand.from_json(response.body)
+    end
+
+    # Fetch a global command for your application.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/application-commands#get-global-application-command)
+    def get_global_application_command(command_id : UInt64 | Snowflake)
+      application_id = client_id
+
+      response = request(
+        :applications_aid_commands,
+        application_id,
+        "GET",
+        "/applications/#{application_id}/commands/#{command_id}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      ApplicationCommand.from_json(response.body)
+    end
+
+    # Edit a global command. Updates will be available in all guilds after 1 hour.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/application-commands#get-global-application-command)
+    def edit_global_application_command(command_id : UInt64 | Snowflake,
+                                        name : String? = nil, description : String? = nil, 
+                                        options : Array(ApplicationCommandOption)? = nil, 
+                                        default_permission : Bool? = nil)
+      application_id = client_id
+
+      json = encode_tuple(
+        name: name,
+        description: description,
+        options: options,
+        default_permission: default_permission,
+      )
+
+      response = request(
+        :applications_aid_commands,
+        application_id,
+        "PATCH",
+        "/applications/#{application_id}/commands/#{command_id}",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+
+      ApplicationCommand.from_json(response.body)
+    end
+
+    # Deletes a global command.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/application-commands#delete-global-application-command)
+    def delete_global_application_command(command_id : UInt64 | Snowflake)
+      application_id = client_id
+
+      response = request(
+        :applications_aid_commands,
+        application_id,
+        "DELETE",
+        "/applications/#{application_id}/commands/#{command_id}",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    # Takes a list of application commands, overwriting the existing global command list for this application. Updates will be available in all guilds after 1 hour. Commands that do not already exist will count toward daily application command create limits.
+    #
+    # NOTE: This will overwrite all types of application commands: slash commands, user commands, and message commands.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-global-application-commands)
+    def bulk_overwrite_global_application_commands(commands : Array(PartialApplicationCommand))
+      application_id = client_id
+
+      response = request(
+        :applications_aid_commands,
+        application_id,
+        "PUT",
+        "/applications/#{application_id}/commands",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        commands.to_json
+      )
+
+      Array(ApplicationCommand).from_json(response.body)
+    end
+
+    # Fetch all of the guild commands for your application for a specific guild.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands)
+    def get_guild_application_commands(guild_id : UInt64 | Snowflake)
+      application_id = client_id
+
+      response = request(
+        :applications_aid_guilds_gid_commands,
+        application_id,
+        "GET",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Array(ApplicationCommand).from_json(response.body)
+    end
+
+    # Create a new guild command. New guild commands will be available in the guild immediately. If the command did not already exist, it will count toward daily application command create limits.
+    #
+    # NOTE: Creating a command with the same name as an existing command for your application will overwrite the old command.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/application-commands#create-guild-application-commands)
+    def create_guild_application_command(guild_id : UInt64 | Snowflake, name : String, description : String, 
+                                         options : Array(ApplicationCommandOption)? = nil, 
+                                         default_permission : Bool? = nil,
+                                         type : ApplicationCommandType? = ApplicationCommandType::ChatInput)
+      application_id = client_id
+      
+      json = encode_tuple(
+        name: name,
+        description: description,
+        options: options,
+        default_permission: default_permission,
+        type: type
+      )
+
+      response = request(
+        :applications_aid_guilds_gid_commands,
+        application_id,
+        "POST",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+
+      ApplicationCommand.from_json(response.body)
+    end
+
+    # Fetch a guild command for your application.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/application-commands#get-guild-application-command)
+    def get_global_application_command(guild_id : UInt64 | Snowflake, command_id : UInt64 | Snowflake)
+      application_id = client_id
+
+      response = request(
+        :applications_aid_guilds_gid_commands_cid,
+        application_id,
+        "GET",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      ApplicationCommand.from_json(response.body)
+    end
+
+    # Edit a guild command. Updates for guild commands will be available immediately.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command)
+    def edit_guild_application_command(guild_id : UInt64 | Snowflake, command_id : UInt64 | Snowflake,
+                                       name : String? = nil, description : String? = nil,
+                                       options : Array(ApplicationCommandOption)? = nil,
+                                       default_permission : Bool? = nil)
+      application_id = client_id
+
+      json = encode_tuple(
+        name: name,
+        description: description,
+        options: options,
+        default_permission: default_permission,
+      )
+
+      response = request(
+        :applications_aid_guilds_gid_commands_cid,
+        application_id,
+        "PATCH",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+
+      ApplicationCommand.from_json(response.body)
+    end
+
+    # Delete a guild command.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#delete-guild-application-command)
+    def delete_guild_application_command(guild_id : UInt64 | Snowflake, command_id : UInt64 | Snowflake)
+      application_id = client_id
+
+      response = request(
+        :applications_aid_guilds_gid_commands_cid,
+        application_id,
+        "DELETE",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    # Takes a list of application commands, overwriting existing commands for the guild.
+    #
+    # NOTE: This will overwrite all types of application commands: slash commands, user commands, and message commands.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/slash-commands#bulk-overwrite-guild-application-commands)
+    def bulk_overwrite_guild_application_commands(guild_id : UInt64 | Snowflake, commands : Array(PartialApplicationCommand))
+      application_id = client_id
+
+      response = request(
+        :applications_aid_guilds_gid_commands,
+        application_id,
+        "PUT",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        commands.to_json
+      )
+
+      Array(ApplicationCommand).from_json(response.body)
+    end
+
+    # Fetches command permissions for all commands for your application in a guild.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/application-commands#get-guild-application-command-permissions)
+    def get_guild_application_command_permissions(guild_id : UInt64 | Snowflake)
+      application_id = client_id
+
+      response = request(
+        :applications_aid_guilds_gid_commands_permissions,
+        application_id,
+        "GET",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/permissions",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Array(GuildApplicationCommandPermissions).from_json(response.body)
+    end
+
+    # Fetches command permissions for a specific command for your application in a guild.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/application-commands#get-application-command-permissions)
+    def get_guild_application_command_permissions(guild_id : UInt64 | Snowflake, command_id : UInt64 | Snowflake)
+      application_id = client_id
+
+      response = request(
+        :applications_aid_guilds_gid_commands_cid_permissions,
+        application_id,
+        "GET",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}/permissions",
+        HTTP::Headers.new,
+        nil
+      )
+
+      GuildApplicationCommandPermissions.from_json(response.body)
+    end
+
+    # Edits command permissions for a specific command for your application in a guild. You can only add up to 10 permission overwrites for a command.
+    #
+    # NOTE: This endpoint will overwrite existing permissions for the command in that guild
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/application-commands#edit-application-command-permissions)
+    def edit_guild_application_command_permissions(guild_id : UInt64 | Snowflake, command_id : UInt64 | Snowflake,
+                                                   permissions : Array(ApplicationCommandPermissions))
+      application_id = client_id
+
+      response = request(
+        :applications_aid_guilds_gid_commands_cid_permissions,
+        application_id,
+        "PUT",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}/permissions",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        {permissions: permissions}.to_json
+      )
+    end
+
+    # Batch edits permissions for all commands in a guild. Takes an array of partial GuildApplicationCommandPermissions objects including id and permissions. You can only add up to 10 permission overwrites for a command.
+    #
+    # NOTE: This endpoint will overwrite all existing permissions for all commands in a guild, including slash commands, user commands, and message commands.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/application-commands#batch-edit-application-command-permissions)
+    def batch_edit_application_command_permissions(guild_id : UInt64 | Snowflake, 
+                                                   permissions : Hash(UInt64 | Snowflake, Array(ApplicationCommandPermissions)))
+      application_id = client_id
+
+      json = permissions.map { |cid, perm| {"id" => cid, "permissions" => perm} }.to_json
+
+      response = request(
+        :applications_aid_guilds_gid_commands_permissions,
+        application_id,
+        "PUT",
+        "/applications/#{application_id}/guilds/#{guild_id}/commands/permissions",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        json
+      )
+    end
+
+    # Create a response to an Interaction from the gateway.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response)
+    def create_interaction_response(interaction_id : UInt64 | Snowflake, interaction_token : String, 
+                                    response : InteractionResponse)
+      response = request(
+        :interactions_iid_itk_callback,
+        interaction_id,
+        "POST",
+        "/interactions/#{interaction_id}/#{interaction_token}/callback",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        response.to_json
+      )
+    end
+
+    # Returns the initial Interaction response.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/receiving-and-responding#get-original-interaction-response)
+    def get_original_interaction_response(interaction_token : String)
+      application_id = client_id
+
+      response = request(
+        :webhooks_aid_itk_messages_original,
+        application_id,
+        "GET",
+        "/webhooks/#{application_id}/#{interaction_token}/messages/@original",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    # Edits the initial Interaction response.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/receiving-and-responding#edit-original-interaction-response)
+    def edit_original_interaction_response(interaction_token : String,
+                                           content : String? = nil, embeds : Array(Embed)? = nil)
+      application_id = client_id
+
+      response = request(
+        :webhooks_aid_itk_messages_original,
+        application_id,
+        "PATCH",
+        "/webhooks/#{application_id}/#{interaction_token}/messages/@original",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        {content: content, embeds: embeds}.to_json
+      )
+    end
+
+    # Deletes the initial Interaction response.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/receiving-and-responding#delete-original-interaction-response)
+    def delete_original_interaction_response(interaction_token : String)
+      application_id = client_id
+
+      response = request(
+        :webhooks_aid_itk_messages_original,
+        application_id,
+        "DELETE",
+        "/webhooks/#{application_id}/#{interaction_token}/messages/@original",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
+    # Create a followup message for an Interaction. Functions the same as `#execute_webhook`, but `wait` is always true.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/receiving-and-responding#create-followup-message)
+    def create_followup_message(interaction_token : String, content : String? = nil,
+                                file : IO? = nil, filename : String? = nil,
+                                embeds : Array(Embed)? = nil, tts : Bool? = nil,
+                                avatar_url : String? = nil, username : String? = nil,
+                                flags : InteractionCallbackDataFlags? = nil)
+      application_id = client_id
+
+      json = encode_tuple(
+        content: content,
+        embeds: embeds,
+        tts: tts,
+        avatar_url: avatar_url,
+        username: username,
+        flags: flags
+      )
+      
+      body, content_type = if file
+        io = IO::Memory.new
+
+        unless filename
+          if file.is_a? File
+            filename = File.basename(file.path)
+          else
+            filename = ""
+          end
+        end
+
+        builder = HTTP::FormData::Builder.new(io)
+        builder.file("file", file, HTTP::FormData::FileMetadata.new(filename: filename))
+        builder.field("payload_json", json)
+        builder.finish
+
+        {io.to_s, builder.content_type}
+      else
+        {json, "application/json"}
+      end
+
+      response = request(
+        :webhooks_aid_itk,
+        application_id,
+        "POST",
+        "/webhooks/#{application_id}/#{interaction_token}",
+        HTTP::Headers{"Content-Type" => content_type},
+        body
+      )
+
+      Message.from_json(response.body)
+    end
+
+    # Returns a followup message for an Interaction.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/receiving-and-responding#get-followup-message)
+    def get_followup_message(interaction_token : String, message_id : UInt64 | Snowflake)
+      application_id = client_id
+
+      response = request(
+        :webhooks_aid_itk_messages_mid,
+        application_id,
+        "GET",
+        "/webhooks/#{application_id}/#{interaction_token}/messages/#{message_id}",
+        HTTP::Headers.new,
+        nil
+      )
+
+      Message.from_json(response.body)
+    end
+
+    # Edits a followup message for an Interaction.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/receiving-and-responding#edit-followup-message)
+    def edit_followup_message(interaction_token : String, message_id : UInt64 | Snowflake,
+                              content : String? = nil, embeds : Array(Embed)? = nil)
+      application_id = client_id
+
+      response = request(
+        :webhooks_aid_itk_messages_original,
+        application_id,
+        "PATCH",
+        "/webhooks/#{application_id}/#{interaction_token}/messages/#{message_id}",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        {content: content, embeds: embeds}.to_json
+      )
+    end
+
+    # Deletes a followup message for an Interaction.
+    #
+    # [API docs for this method](https://discord.com/developers/docs/interactions/receiving-and-responding#delete-followup-message)
+    def delete_followup_message(interaction_token : String, message_id : UInt64 | Snowflake)
+      application_id = client_id
+
+      response = request(
+        :webhooks_aid_itk_messages_original,
+        application_id,
+        "DELETE",
+        "/webhooks/#{application_id}/#{interaction_token}/messages/#{message_id}",
+        HTTP::Headers.new,
+        nil
+      )
+    end
   end
 end

--- a/src/discordcr/snowflake.cr
+++ b/src/discordcr/snowflake.cr
@@ -24,6 +24,11 @@ module Discord
       new(value)
     end
 
+    # Allows serialization of snowflake as an object key
+    def self.from_json_object_key?(key : String)
+      Snowflake.new(key)
+    end
+
     def initialize(@value : UInt64)
     end
 


### PR DESCRIPTION
Now that #19 and #20 are being kinda dead, here's my attempt to implement all these features. The added lines are about a quarter of that in #19 and #20, and while this may not be a good implementation, at least I will try to be active as I can and address any problems pointed out.
This pull request is based on the changes made in #30 to avoid conflicts, so it'll remain as a draft until #30 is merged.
This is the first time for me to implement all this stuff while reading docs, and the changes ended up pretty big still, so I would like to have some feedback first.

Some notes about the changes:
- You can ignore most of the changes in mappings/channel.cr as they're from #30
- There are some shorthand methods that can be used when declaring command structures
  - I know that the lib is supposed to be minimal but the names are already getting long and it's only verbose, so this is providing some ways to make it shorter
  - [in ApplicationCommandOption](https://github.com/shardlab/discordcr/compare/master...soya-daizu:interactions?expand=1#diff-aa3726680505b4185f1893cba22d5f60392688d9cce299a229c8d852fa341d9bR72)
  - [in ApplicationCommandPermissions](https://github.com/shardlab/discordcr/compare/master...soya-daizu:interactions?expand=1#diff-aa3726680505b4185f1893cba22d5f60392688d9cce299a229c8d852fa341d9bR163)
  - [in InteractionResponse](https://github.com/shardlab/discordcr/compare/master...soya-daizu:interactions?expand=1#diff-6d9c99bde2f7ecf474ad5dedcca9a7f8f878283f245cf3a7ad17222a7dffb7dcR106)
- Should we use term "command" instead of "application command" across the board? `bulk_overwrite_guild_application_commands` feels too long for a method name
- `PartialApplicationCommand`
  - Used only for declaring commands to register
  - Does not have `id` and other fields that are not used when registering
- `ApplicationCommandOptionChoice` and `ApplicationCommandInteractionDataOption`
  - API supports value between -2^53 and 2^53, I think we're good to remove `Int32` and `Float32` from the types
- About the [changes](https://github.com/shardlab/discordcr/compare/master...soya-daizu:interactions?expand=1#diff-1eb3aabf6f908245a3104c7e4e8f6fab317994c70733803c7f7e5b711020d22fL159) in `PartialGuildMember`
  - Partial guild member objects sent in Resolved Interaction Data does not contain `deaf` and `mute` fields
- [This change](https://github.com/shardlab/discordcr/compare/master...soya-daizu:interactions?expand=1#diff-d0fc8f72dc119a2dd756da7e9cdf39ccdb334c7643143eb0ba09a0720270d2e4R28) allows Snowflakes in `ResolvedInteractionData` to be serialized
- [Interaction Data](https://github.com/shardlab/discordcr/compare/master...soya-daizu:interactions?expand=1#diff-6d9c99bde2f7ecf474ad5dedcca9a7f8f878283f245cf3a7ad17222a7dffb7dcR27) has different structures for each interaction type, and we're splitting it into two
- The same applies to [Message Components](https://github.com/shardlab/discordcr/compare/master...soya-daizu:interactions?expand=1#diff-f8a92c80a28fea80efe1b452552edb3c9d562b22329b08a86cde924db9c01ec9R18)
- We can perhaps cover some more features in the example bot?