### PR TITLE
fix: cache the guild_id->stage when resolved from the API

### DIFF
--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -512,7 +512,7 @@ module Discord
 
         payload.stage_instances.each do |stage_instance|
           cache stage_instance
-          @cache.try &.add_guild_stage_instance(guild.id, stage_instance.id)
+          @cache.try &.add_guild_stage_instance(guild.id, stage_instance.channel_id)
         end
 
         call_event guild_create, payload
@@ -646,7 +646,7 @@ module Discord
         payload = StageInstance.from_json(data)
         cache payload
 
-        @cache.try &.add_guild_stage_instance(payload.guild_id, payload.id)
+        @cache.try &.add_guild_stage_instance(payload.guild_id, payload.channel_id)
 
         call_event stage_instance_create, payload
       when "STAGE_INSTANCE_UPDATE"
@@ -657,8 +657,8 @@ module Discord
       when "STAGE_INSTANCE_DELETE"
         payload = StageInstance.from_json(data)
 
-        @cache.try &.delete_stage_instance(payload.id)
-        @cache.try &.remove_guild_stage_instance(payload.guild_id, payload.id)
+        @cache.try &.delete_stage_instance(payload.channel_id)
+        @cache.try &.remove_guild_stage_instance(payload.guild_id, payload.channel_id)
 
         call_event stage_instance_delete, payload
       when "TYPING_START"


### PR DESCRIPTION
In the fallback for resolving the stage_id in `Cache#resolve_stage_instance`, the guild_id -> stage_id wasn't being cached.