### PR TITLE
Feat: Guild Scheduled Events

### DIFF
--- a/src/discordcr/cache.cr
+++ b/src/discordcr/cache.cr
@@ -47,6 +47,10 @@ module Discord
     # affected guilds would be missing here too.
     getter guilds
 
+    # A map of cached scheduled events, i.e. all scheduled events on all servers
+    # the bot is on.
+    getter scheduled_events
+    
     # A map of cached stage instances, i. e. all stage instances on all servers
     # the bot is on.
     getter stage_instances
@@ -73,6 +77,14 @@ module Discord
     # [channel IDs]}.
     getter guild_channels
 
+    # Mapping of guilds to the scheduled events on them, represented as {guild ID =>
+    # [scheduled event IDs]}.
+    getter guild_scheduled_events
+
+    # Mapping of guild scheduled event to the users subscribed to them, represented as
+    # {guild scheduled event ID => [user IDs]}.
+    getter guild_scheduled_event_users
+
     # Mapping of guilds to the Stage instances on them, represented as {guild ID =>
     # [stage instance IDs]}.
     getter guild_stage_instances
@@ -89,12 +101,15 @@ module Discord
       @guilds = Hash(UInt64, Guild).new
       @members = Hash(UInt64, Hash(UInt64, GuildMember)).new
       @roles = Hash(UInt64, Role).new
+      @scheduled_events = Hash(UInt64, GuildScheduledEvent).new
       @stage_instances = Hash(UInt64, StageInstance).new
 
       @dm_channels = Hash(UInt64, UInt64).new
 
       @guild_roles = Hash(UInt64, Array(UInt64)).new
       @guild_channels = Hash(UInt64, Array(UInt64)).new
+      @guild_scheduled_events = Hash(UInt64, Array(UInt64)).new
+      @guild_scheduled_event_users = Hash(UInt64, Array(UInt64)).new
       @guild_stage_instances = Hash(UInt64, Array(UInt64)).new
 
       @voice_states = Hash(UInt64, Hash(UInt64, VoiceState)).new
@@ -136,6 +151,43 @@ module Discord
     # all roles should be cached at all times so it won't be a problem.
     def resolve_role(id : UInt64 | Snowflake) : Role
       @roles[id.to_u64] # There is no endpoint for getting an individual role, so we will have to ignore that case for now.
+    end
+
+    # Resolves a guild scheduled event by the *guild_id* of the guild the scheduled
+    # event is on, and the *event_id* of the event itself. An API request will be performed
+    # if the object is not cached.
+    def resolve_guild_scheduled_event(guild_id : UInt64 | Snowflake, event_id : UInt64 | Snowflake) : GuildScheduledEvent
+      guild_id = guild_id.to_u64
+      event_id = event_id.to_u64
+      @scheduled_events.fetch(event_id) do
+        event = @client.get_guild_scheduled_event(guild_id, event_id)
+        cache(event)
+        add_guild_scheduled_event(event.guild_id, event.id)
+        event
+      end
+    end
+
+    # Resolves an array of users by the *guild_id* of the guild the  guild scheduled event
+    # is on, and the *event_id* of the event itself. API requests will be performed
+    # if the object is not cached. If a limit is provided, the subscribed users will
+    # only be cached if the number of users is below the limit, to ensure it remains synced.
+    # User and member data is cached regardless. Member data is included if *with_member* is true. 
+    def resolve_guild_scheduled_event_users(guild_id : UInt64 | Snowflake, event_id : UInt64 | Snowflake,
+                                            with_member : Bool? = nil, limit : Int32? = nil) : Array(UInt64)
+      guild_id = guild_id.to_u64
+      event_id = event_id.to_u64
+      @guild_scheduled_event_users.fetch(event_id) do
+        users = @client.page_guild_scheduled_event_users(guild_id, event_id, with_member: with_member, limit: limit).to_a
+        
+        users.each do |user|
+          cache user.user
+          if member = user.member
+            cache member, guild_id
+          end
+        end
+        return users.map &.user.id.to_u64 if users.size == limit
+        @guild_scheduled_event_users[event_id] = users.map &.user.id.to_u64
+      end
     end
 
     # Resolves a Stage instance by its *ID*.
@@ -183,6 +235,10 @@ module Discord
     # Deletes a guild from the cache given its *ID*.
     def delete_guild(id : UInt64 | Snowflake)
       @guilds.delete(id.to_u64)
+    end
+
+    def delete_scheduled_event(id : UInt64 | Snowflake)
+      @scheduled_events.delete(id.to_u64)
     end
 
     # Deletes a stage instance from the cache given its *ID*.
@@ -245,6 +301,11 @@ module Discord
     # Adds a specific *role* to the cache.
     def cache(role : Role)
       @roles[role.id.to_u64] = role
+    end
+
+    # Adds a specific *guild scheduled event* to the cache.
+    def cache(guild_scheduled_event : GuildScheduledEvent)
+      @scheduled_events[guild_scheduled_event.id.to_u64] = guild_scheduled_event
     end
 
     # Adds a specific *Stage instance* to the cache.
@@ -322,6 +383,49 @@ module Discord
       guild_id = guild_id.to_u64
       channel_id = channel_id.to_u64
       @guild_channels[guild_id]?.try { |local_channels| local_channels.delete(channel_id) }
+    end
+
+    # Returns all guild scheduled events, identified by the guild's *guild_id*.
+    def guild_scheduled_events(guild_id : UInt64 | Snowflake) : Array(UInt64)
+      @guild_scheduled_events[guild_id.to_u64]
+    end
+
+    # Marks a guild scheduled event, identified by the *event_id*, as belonging to a particular
+    # guild, identified by the *guild_id*.
+    def add_guild_scheduled_event(guild_id : UInt64 | Snowflake, event_id : UInt64 | Snowflake)
+      local_events = @guild_scheduled_events[guild_id.to_u64] ||= [] of UInt64
+      local_events << event_id.to_u64
+    end
+
+    # Marks a guild scheduled event, identified by the *event_id*, as belonging to a particular
+    # guild, identified by the *guild_id*. This should only be called when the event is created
+    # during a websocket connection, not a GUILD_CREATE, otherwise the event users cache will be out of sync.
+    def create_guild_scheduled_event(guild_id : UInt64 | Snowflake, event_id : UInt64 | Snowflake)
+      add_guild_scheduled_event(guild_id, event_id)
+      @guild_scheduled_event_users[event_id.to_u64] = [] of UInt64
+    end
+
+    # Marks a guild scheduled event, identified by the *event_id*, as not belonging to a particular guild,
+    # identified by its *guild_id*, anymore.
+    def remove_guild_scheduled_event(guild_id : UInt64 | Snowflake, event_id : UInt64 | Snowflake)
+      @guild_scheduled_events[guild_id.to_u64]?.try { |local_events| local_events.delete(event_id.to_u64) }
+    end
+
+    # Returns all guild scheduled event users, identified by its *event_id*.
+    def guild_scheduled_event_users(event_id : UInt64 | Snowflake) : Array(UInt64)
+      @guild_scheduled_event_users[event_id.to_u64]
+    end
+
+    # Marks a user, identified by the *user_id*, as subscribed to a particular guild scheduled event,
+    # identified by the *event_id*.
+    def add_guild_scheduled_event_user(event_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake)
+      @guild_scheduled_event_users[event_id.to_u64]?.try { |local_event_users| local_event_users << user_id.to_u64 }
+    end
+
+    # Marks a user, identified by the *user_id*, as unsubscribed to a particular guild scheduled event,
+    # identified by the *event_id*.
+    def remove_guild_scheduled_event_user(event_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake)
+      @guild_scheduled_event_users[event_id.to_u64]?.try { |local_event_users| local_event_users.delete(user_id.to_u64) }
     end
 
     # Returns all Stage instances of a guild, identified by its *guild_id*.

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -592,6 +592,26 @@ module Discord
         @cache.try &.remove_guild_role(payload.guild_id, payload.role_id)
 
         call_event guild_role_delete, payload
+      when "GUILD_SCHEDULED_EVENT_CREATE"
+        payload = GuildScheduledEvent.from_json(data)
+
+        call_event guild_scheduled_event_create, payload
+      when "GUILD_SCHEDULED_EVENT_UPDATE"
+        payload = GuildScheduledEvent.from_json(data)
+
+        call_event guild_scheduled_event_update, payload
+      when "GUILD_SCHEDULED_EVENT_DELETE"
+        payload = GuildScheduledEvent.from_json(data)
+
+        call_event guild_scheduled_event_delete, payload
+      when "GUILD_SCHEDULED_EVENT_USER_ADD"
+        payload = Gateway::GuildScheduledEventUserPayload.from_json(data)
+
+        call_event guild_scheduled_event_user_add, payload
+      when "GUILD_SCHEDULED_EVENT_USER_REMOVE"
+        payload = Gateway::GuildScheduledEventUserPayload.from_json(data)
+
+        call_event guild_scheduled_event_user_remove, payload
       when "INVITE_CREATE"
         payload = Gateway::InviteCreatePayload.from_json(data)
 
@@ -894,6 +914,31 @@ module Discord
     #
     # [API docs for this event](https://discord.com/developers/docs/topics/gateway#guild-role-delete)
     event guild_role_delete, Gateway::GuildRoleDeletePayload
+
+    # Called when a guild scheduled event is created.
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-create)
+    event guild_scheduled_event_create, GuildScheduledEvent
+
+    # Called when a guild scheduled event is updated.
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-update)
+    event guild_scheduled_event_update, GuildScheduledEvent
+
+    # Called when a guild scheduled event is deleted.
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-delete)
+    event guild_scheduled_event_delete, GuildScheduledEvent
+
+    # Called when a user subscribes to a guild scheduled event
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-user-add)
+    event guild_scheduled_event_user_add, Gateway::GuildScheduledEventUserPayload
+
+    # Called when a user unsubscribes from a guild scheduled event
+    #
+    # [API docs for this event](https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-user-remove)
+    event guild_scheduled_event_user_remove, Gateway::GuildScheduledEventUserPayload
 
     # Called when an invite is created on a guild.
     #

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -84,6 +84,7 @@ module Discord
       DirectMessages         = 1 << 12
       DirectMessageReactions = 1 << 13
       DirectMessageTyping    = 1 << 14
+      GuildScheduledEvents   = 1 << 16
 
       # Generates an Unprivileged intents constant, removing GuildMembers and GuildPresences.
       {% begin %}
@@ -326,6 +327,14 @@ module Discord
 
       property guild_id : Snowflake
       property role_id : Snowflake
+    end
+
+    struct GuildScheduledEventUserPayload
+      include JSON::Serializable
+
+      property guild_scheduled_event_id : Snowflake
+      property user_id : Snowflake
+      property guild_id : Snowflake
     end
 
     struct InviteCreatePayload

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -233,6 +233,7 @@ module Discord
       property system_channel_id : Snowflake?
       property stage_instances : Array(StageInstance)
       property threads : Array(Channel)
+      property guild_scheduled_events : Array(GuildScheduledEvent)?
 
       {% unless flag?(:correct_english) %}
         def emojis

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -28,6 +28,7 @@ module Discord
     property default_message_notifications : UInt8
     property explicit_content_filter : UInt8
     property system_channel_id : Snowflake?
+    property guild_scheduled_events : Array(GuildScheduledEvent)?
 
     # :nodoc:
     def initialize(payload : Gateway::GuildCreatePayload)
@@ -48,6 +49,7 @@ module Discord
       @default_message_notifications = payload.default_message_notifications
       @explicit_content_filter = payload.explicit_content_filter
       @system_channel_id = payload.system_channel_id
+      @guild_scheduled_events = payload.guild_scheduled_events
     end
 
     {% unless flag?(:correct_english) %}
@@ -335,5 +337,53 @@ module Discord
     property game : GamePlaying?
     property status : String
     property activities : Array(GamePlaying)
+  end
+
+  struct GuildScheduledEvent
+    include JSON::Serializable
+
+    enum PrivacyLevel : UInt8
+      GUILD_ONLY = 2
+    end
+
+    enum Status : UInt8
+      SCHEDULED = 1
+      ACTIVE    = 2
+      COMPLETED = 3
+      CANCELLED = 4
+    end
+
+    enum EntityType : UInt8
+      STAGE_INSTANCE = 1
+      VOICE          = 2
+      EXTERNAL       = 3
+    end
+
+    struct EntityMetadata
+      include JSON::Serializable
+
+      property location : String?
+    end
+
+    property id : Snowflake
+    property guild_id : Snowflake
+    property channel_id : Snowflake?
+    property creator_id : Snowflake?
+    property name : String
+    property description : String?
+    @[JSON::Field(converter: Discord::TimestampConverter)]
+    property scheduled_start_time : Time
+    @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
+    property scheduled_end_time : Time?
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::GuildScheduledEvent::PrivacyLevel))]
+    property privacy_level : PrivacyLevel
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::GuildScheduledEvent::Status))]
+    property status : Status
+    @[JSON::Field(converter: Enum::ValueConverter(Discord::GuildScheduledEvent::EntityType))]
+    property entity_type : EntityType
+    property entity_id : Snowflake?
+    property entity_metadata : EntityMetadata
+    property creator : User?
+    property user_count : Int32?
   end
 end

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -344,6 +344,10 @@ module Discord
 
     enum PrivacyLevel : UInt8
       GUILD_ONLY = 2
+
+      def to_json(json : JSON::Builder)
+        json.number(value)
+      end
     end
 
     enum Status : UInt8
@@ -351,18 +355,37 @@ module Discord
       ACTIVE    = 2
       COMPLETED = 3
       CANCELLED = 4
+
+      def to_json(json : JSON::Builder)
+        json.number(value)
+      end
     end
 
     enum EntityType : UInt8
       STAGE_INSTANCE = 1
       VOICE          = 2
       EXTERNAL       = 3
+
+      def to_json(json : JSON::Builder)
+        json.number(value)
+      end
     end
 
     struct EntityMetadata
       include JSON::Serializable
 
       property location : String?
+
+      def initialize(@location)
+      end
+    end
+
+    struct EventUser
+      include JSON::Serializable
+
+      property guild_scheduled_event_id : Snowflake
+      property user : User
+      property member : GuildMember?
     end
 
     property id : Snowflake

--- a/src/discordcr/mappings/permissions.cr
+++ b/src/discordcr/mappings/permissions.cr
@@ -33,6 +33,7 @@ module Discord
     ManageEmojis           = 1 << 30
     UseApplicationCommands = 1 << 31
     RequestToSpeak         = 1 << 32
+    ManageEvents           = 1 << 33
     ManageThreads          = 1 << 34
     UsePrivateThreads      = 1 << 36
     UseExternalStickers    = 1 << 37


### PR DESCRIPTION
This adds Mappings, API methods, Permissions, Websocket, Caching for the recently released Guild Scheduled Events

Relevant docs are [here](https://discord.com/developers/docs/resources/guild-scheduled-event).

The commits have been separated by each aspect for ease of review.

This has been tested through development, but some bugs could remain as I haven't done a final test of each method and there are no specs.

There are various decisions I made that should be discussed before being merged, like the start time on a newly created event default, the caching code for event users, and perhaps others.

Please reach out in the discord for any small questions, and follow up on the issue on what was discussed, to keep the spam low but the information relevant.