### PR TITLE
fix: voice regions

### DIFF
--- a/examples/voice_send.cr
+++ b/examples/voice_send.cr
@@ -43,7 +43,8 @@ client.on_message_create do |payload|
 
     reply = begin
       vs = cache.resolve_voice_state(payload.guild_id.not_nil!, payload.author.id)
-      "You are connected to channel #{vs.channel_id} at guild #{vs.guild_id}"
+      vc = cache.resolve_channel(vs.channel_id.not_nil!)
+      "You are connected to channel #{vs.channel_id} (region: #{vc.rtc_region}) at guild #{vs.guild_id}"
     rescue
       "No voice state"
     end

--- a/examples/voice_send.cr
+++ b/examples/voice_send.cr
@@ -49,6 +49,18 @@ client.on_message_create do |payload|
       "No voice state"
     end
     client.create_message(payload.channel_id, reply)
+  elsif payload.content.starts_with? "!vr"
+    # Used as:
+    # !vr [guild ID]
+
+    regions : Array(Discord::VoiceRegion) = if payload.content.size > 4
+      id = payload.content[4..-1]
+      client.get_guild_voice_regions(id.to_u64)
+    else
+      client.list_voice_regions
+    end
+
+    client.create_message(payload.channel_id, "Voice Regions: #{regions.map(&.name).join(", ")}")
   elsif payload.content.starts_with? "!play_dca "
     # Used as:
     # !play_dca <filename>

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -190,7 +190,7 @@ module Discord
     property rate_limit_per_user : Int32?
     @[JSON::Field(converter: Discord::MaybeTimestampConverter)]
     property last_pin_timestamp : Time?
-    property rtc_region : VoiceRegion?
+    property rtc_region : String?
     property video_quality_mode : VideoQualityMode?
     property thread_metadata : ThreadMetaData?
     property message_count : UInt32?

--- a/src/discordcr/mappings/voice.cr
+++ b/src/discordcr/mappings/voice.cr
@@ -24,10 +24,8 @@ module Discord
 
     property id : String
     property name : String
-    property sample_hostname : String
-    property sample_port : UInt16
-    property custom : Bool?
-    property vip : Bool
+    property custom : Bool
+    property deprecated : Bool
     property optimal : Bool
   end
 end


### PR DESCRIPTION
Currently trying to start example bot will raise following exception:
```
2022-01-30T12:38:00.781780Z   INFO - discord.rest: [HTTP OUT] GET /gateway (0 bytes)
2022-01-30T12:38:00.826021Z   INFO - discord.rest: [HTTP IN] 200 OK (35 bytes)
2022-01-30T12:38:00.826047Z   INFO - discord.ws: Connecting to gateway.discord.gg:443/?encoding=json&v=9&compress=zlib-stream
2022-01-30T12:38:01.228052Z   INFO - discord.client: [Client] Received READY, v: 9
2022-01-30T12:38:01.231229Z  ERROR - discord.client: [Client] An exception occurred during message parsing! Please report this.
Expected BeginObject but was String at line 1, column 4380
  parsing Discord::VoiceRegion at line 1, column 4372
  parsing Discord::Channel#rtc_region at line 1, column 4359
  parsing Discord::Gateway::GuildCreatePayload#channels at line 1, column 3912 (JSON::SerializableError)
  from /usr/share/crystal/src/json/serialization.cr:159:7 in 'initialize:__pull_for_json_serializable'
  
  ...
```

There is definitely problems with VoiceRegion serialization, which are fixed in this PR. Maybe there is more 🤔 

---
https://discord.com/developers/docs/resources/channel#channel-object-channel-structure
https://discord.com/developers/docs/resources/voice#voice-region-object-voice-region-structure