### PR TITLE
fix: ci trigger on pull_request

### DIFF
--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -8,11 +8,11 @@ on:
       - v*
     paths-ignore:
       - "**.md"
-    pull_request:
-      branches:
-        - master
-      paths-ignore:
-        - "**.md"
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - "**.md"
 jobs:
   deploy:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
CI doesn't get triggered on PRs due to an extra tab on the pull_request section.