### PR TITLE
fix: permissions should serialize to a string

### DIFF
--- a/src/discordcr/mappings/permissions.cr
+++ b/src/discordcr/mappings/permissions.cr
@@ -42,7 +42,7 @@ module Discord
     end
 
     def to_json(json : JSON::Builder)
-      json.number(value)
+      json.string(value)
     end
   end
 end


### PR DESCRIPTION
As of api v8, all permissions are serialized as strings