### PR TITLE
Timeouts

### DIFF
--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -101,6 +101,7 @@ module Discord
     property premium_since : Time?
     property deaf : Bool?
     property mute : Bool?
+    property communication_disabled_until : Time?
 
     # :nodoc:
     def initialize(user : User, partial_member : PartialGuildMember)
@@ -111,6 +112,7 @@ module Discord
       @premium_since = partial_member.premium_since
       @mute = partial_member.mute
       @deaf = partial_member.deaf
+      @communication_disabled_until = partial_member.communication_disabled_until
     end
 
     # :nodoc:
@@ -158,6 +160,7 @@ module Discord
     property premium_since : Time?
     property deaf : Bool
     property mute : Bool
+    property communication_disabled_until : Time?
   end
 
   struct Integration

--- a/src/discordcr/mappings/permissions.cr
+++ b/src/discordcr/mappings/permissions.cr
@@ -36,6 +36,7 @@ module Discord
     ManageThreads          = 1 << 34
     UsePrivateThreads      = 1 << 36
     UseExternalStickers    = 1 << 37
+    ModerateMembers        = 1 << 40
 
     def self.new(pull : JSON::PullParser)
       Permissions.new(pull.read_string.to_u64)

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -1348,18 +1348,22 @@ module Discord
     #  - and the "Move Members" permission as well as the "Connect" permission
     #    to the new channel when changing voice channel ID.
     #
-    # NOTE: To remove a member's nickname, you can send an empty string for the `nick` argument.
+    # To remove a member's nickname, you can send an empty string for the `nick` argument.
+    # To set or remove a timeout, you must have the `MANAGE_MEMBERS` permission.
+    # The `communication_disabled_until` argument takes a time up to 28 days in the future, or nil to remove.
     #
     # [API docs for this method](https://discord.com/developers/docs/resources/guild#modify-guild-member)
     def modify_guild_member(guild_id : UInt64 | Snowflake, user_id : UInt64 | Snowflake, nick : String? = nil,
                             roles : Array(UInt64 | Snowflake)? = nil, mute : Bool? = nil, deaf : Bool? = nil,
-                            channel_id : UInt64 | Snowflake | Nil = nil, reason : String? = nil)
+                            channel_id : UInt64 | Snowflake | Nil = nil, communication_disabled_until : Time? = nil,
+                            reason : String? = nil)
       json = encode_tuple(
         nick: nick,
         roles: roles,
         mute: mute,
         deaf: deaf,
-        channel_id: channel_id
+        channel_id: channel_id,
+        communication_disabled_until: communication_disabled_until
       )
 
       headers = HTTP::Headers{


### PR DESCRIPTION
Allows setting/remove a timeout from a member using the traditional modify_member method.
Don't really know how much it is necessary to include the field on `PartialGuildMember` but I added it just in case.