### PR TITLE
fix: upd discovery

### DIFF
--- a/spec/voice_spec.cr
+++ b/spec/voice_spec.cr
@@ -15,16 +15,16 @@ describe Discord::VoiceUDP do
   it "sends discovery" do
     with_voice_udp do |server, client|
       client.send_discovery
-      data = Bytes.new(70)
+      data = Bytes.new(74)
       server.receive(data)
-      data[0, 4].should eq Bytes[0, 0, 0, 1]
+      data[4, 4].should eq Bytes[0, 0, 0, 1]
     end
   end
 
   it "receives discovery reply" do
     with_voice_udp do |server, client|
       io = IO::Memory.new
-      io.write Bytes.new(4)
+      io.write Bytes.new(8)
       io.print("ip address".ljust(64, '\0'))
       io.write_bytes(2_u16, IO::ByteFormat::BigEndian)
       data = io.to_slice

--- a/src/discordcr/voice.cr
+++ b/src/discordcr/voice.cr
@@ -206,7 +206,7 @@ module Discord
     # IP so we can select the protocol on the VWS
     def send_discovery
       data = Bytes.new(74)
-      IO::ByteFormat::BigEndian.encode(1_u16, data[0, 2]) # Mark as request
+      IO::ByteFormat::BigEndian.encode(1_u16, data[0, 2])  # Mark as request
       IO::ByteFormat::BigEndian.encode(70_u16, data[2, 2]) # Message size
       IO::ByteFormat::BigEndian.encode(@ssrc.not_nil!, data[4, 4])
       @socket.write(data)


### PR DESCRIPTION
Recently 70 bytes long messages for UDP discovery [were deprecated](https://discord.com/channels/613425648685547541/697138785317814292/1080623873629884486). From now on they should be prepended with 4 bytes of utility info (see [docs](https://discord.com/developers/docs/topics/voice-connections#ip-discovery)). This PR addresses this change